### PR TITLE
Add post method to delete file route

### DIFF
--- a/app.py
+++ b/app.py
@@ -301,7 +301,7 @@ async def upload_files() -> Response:
     return response
 
 
-@app.route("/delete_file", methods=["DELETE"])
+@app.route("/delete_file", methods=["DELETE", "POST"])
 async def delete_file() -> Response:
     """
     Deletes a file from the server.


### PR DESCRIPTION
This pull request adds a post method to the delete file route in order to allow for file deletion using both the DELETE and POST HTTP methods.