### PR TITLE
Fix deprecated actions/upload-artifact@v3 in docker-pipeline.yaml

### DIFF
--- a/.github/workflows/docker-pipeline.yaml
+++ b/.github/workflows/docker-pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
           tags: dora-backend:latest
           outputs: type=docker, dest=/tmp/dora-backend.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dora-backend
           path: /tmp/dora-backend.tar
@@ -29,7 +29,7 @@ jobs:
     needs: build
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dora-backend
           path: /tmp

--- a/.github/workflows/docker-pipeline.yaml
+++ b/.github/workflows/docker-pipeline.yaml
@@ -41,6 +41,48 @@ jobs:
         run: |
           docker load --input /tmp/dora-backend.tar
           docker image ls -a
+      - name: Set up dummy config for compose smoke test
+        run: |
+          mkdir -p settings ./ci-models/chat ./ci-models/embedding
+
+          cat <<EOF > .env
+          OPENAI_API_KEY=sk-dummy-ci-key
+          FILE_PATH=/tmp/dummy.pdf
+          EOF
+
+          cat <<EOF > settings/.app.env
+          CURRENT_ENV=TST
+          LOGGING_FILE_PATH=/app/logs/dora.log
+          EOF
+
+          cat <<EOF > settings/.retrieval.env
+          CHUNK_SIZE=512
+          TOP_K_DOCUMENTS=5
+          MINIMUM_ACCURACY=0.80
+          FETCH_K_DOCUMENTS=100
+          LAMBDA_MULT=0.2
+          STRATEGY=mmr
+          LAST_N_MESSAGES=5
+          CHAT_HISTORY_CONNECTION_STRING=sqlite:///dummy.db
+          EOF
+
+          cat <<EOF > settings/.mariadb.env
+          MARIADB_USER=dora_user
+          MARIADB_ROOT_PASSWORD=dummy_root_password
+          MARIADB_PASSWORD=dummy_password
+          MARIADB_INSTANCE_URL=mariadb+mariadbconnector://dora_user:dummy_password@dora-mariadb
+          EOF
+
+          cat <<EOF > settings/.model.env
+          CHAT_MODEL_VENDOR_NAME=openai
+          CHAT_MODEL_NAME=gpt-turbo-3.5
+          EMBEDDING_MODEL_VENDOR_NAME=openai
+          EMBEDDING_MODEL_NAME=text-embedding-ada-002
+          SENTENCE_TRANSFORMERS_HOME=/models/embedding_model
+          EOF
+
+          echo "CHAT_MODEL_FOLDER_PATH=$(pwd)/ci-models/chat" >> "$GITHUB_ENV"
+          echo "EMBEDDING_MODEL_FOLDER_PATH=$(pwd)/ci-models/embedding" >> "$GITHUB_ENV"
       - name: Docker Compose Config
         run: |
           docker compose config -o docker-compose-filled.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,23 +15,28 @@ ENV POETRY_HOME="/opt/poetry" \
     POETRY_CACHE_DIR="/tmp/poetry_cache"
 ENV PATH="$PATH:$POETRY_HOME/bin"
 
+# Install MariaDB Connector/C dev headers so the `mariadb` package can be built
+# from source (PyPI only ships Windows wheels for it; on Linux, pip/poetry
+# always builds it from the sdist, which needs `mariadb_config` on PATH at
+# build time).
+# NOTE: we deliberately run the repo-setup + install directly in this stage
+# instead of copying apt sources state from a separate stage: the
+# `mariadb_repo_setup` script's output file name/format (one-line `.list` vs.
+# deb822 `.sources`) is an undocumented implementation detail that has changed
+# upstream, which makes cross-stage COPY of that file fragile.
+RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget gnupg \
+    && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
+    && chmod +x mariadb_repo_setup \
+    && ./mariadb_repo_setup --mariadb-server-version="mariadb-10.11.18" \
+    && apt-get update && apt-get install -y libmariadb3 libmariadb-dev \
+    && rm -f mariadb_repo_setup
+
 # Install Poetry
 RUN pip install poetry
 
 # Install necessary dependencies
 RUN poetry config installer.max-workers 10
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install -v --no-root
-
-#-----------------------------------------------------------------------------------
-## Install MariaDB Connector/C
-
-FROM ubuntu:22.04 AS mariadb-connector-c
-
-RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget curl gnupg
-RUN wget https://r.mariadb.com/downloads/mariadb_repo_setup
-RUN chmod +x mariadb_repo_setup
-RUN ./mariadb_repo_setup --mariadb-server-version="mariadb-10.6"
-RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y libmariadb3 libmariadb-dev
 
 #-----------------------------------------------------------------------------------
 
@@ -90,8 +95,21 @@ ENV VIRTUAL_ENV=/app/.venv \
 # Copy the virtual environment from the builder
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
-# # Copy MariaDB Connector/C
-COPY --from=mariadb-connector-c /etc/apt/sources.list.d/mariadb.list /etc/apt/sources.list.d/mariadb.list
+# Install MariaDB Connector/C runtime library.
+# We run the full repo-setup + install here (rather than COPYing apt sources
+# state from another stage) because `mariadb_repo_setup`'s output file
+# name/format is an undocumented, unstable detail of the upstream script (it
+# has switched between the one-line `.list` format and the deb822 `.sources`
+# format), and copying that file between stages breaks silently when it
+# changes. Only the shared library is needed at runtime (not the -dev
+# headers, which are only required when building the `mariadb` wheel in the
+# builder stage above).
+RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget gnupg \
+    && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
+    && chmod +x mariadb_repo_setup \
+    && ./mariadb_repo_setup --mariadb-server-version="mariadb-10.11.18" \
+    && apt-get update && apt-get install -y libmariadb3 \
+    && rm -f mariadb_repo_setup
 
 
 

--- a/Dockerfile_with_Proxy
+++ b/Dockerfile_with_Proxy
@@ -27,21 +27,25 @@ RUN pip config set global.proxy ${HTTP_PROXY}
 
 RUN pip install poetry
 
+# Install MariaDB Connector/C dev headers so the `mariadb` package can be built
+# from source (PyPI only ships Windows wheels for it; on Linux, pip/poetry
+# always builds it from the sdist, which needs `mariadb_config` on PATH at
+# build time).
+# NOTE: we deliberately run the repo-setup + install directly in this stage
+# instead of copying apt sources state from a separate stage: the
+# `mariadb_repo_setup` script's output file name/format (one-line `.list` vs.
+# deb822 `.sources`) is an undocumented implementation detail that has changed
+# upstream, which makes cross-stage COPY of that file fragile.
+RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget gnupg \
+    && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
+    && chmod +x mariadb_repo_setup \
+    && ./mariadb_repo_setup --mariadb-server-version="mariadb-10.11.18" \
+    && apt-get update && apt-get install -y libmariadb3 libmariadb-dev \
+    && rm -f mariadb_repo_setup
+
 # Install necessary dependencies
 RUN poetry config installer.max-workers 10
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install -v --without dev --no-root
-
-#-----------------------------------------------------------------------------------
-## Install MariaDB Connector/C
-
-FROM ubuntu:22.04 as mariadb-connector-c
-
-RUN echo ${http_proxy}
-RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget curl gnupg
-RUN wget https://r.mariadb.com/downloads/mariadb_repo_setup
-RUN chmod +x mariadb_repo_setup
-RUN ./mariadb_repo_setup --mariadb-server-version="mariadb-10.6"
-RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y libmariadb3 libmariadb-dev
 
 #-----------------------------------------------------------------------------------
 
@@ -100,8 +104,21 @@ ENV VIRTUAL_ENV=/app/.venv \
 # Copy the virtual environment from the builder
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
-# # Copy MariaDB Connector/C
-COPY --from=mariadb-connector-c /etc/apt/sources.list.d/mariadb.list /etc/apt/sources.list.d/mariadb.list
+# Install MariaDB Connector/C runtime library.
+# We run the full repo-setup + install here (rather than COPYing apt sources
+# state from another stage) because `mariadb_repo_setup`'s output file
+# name/format is an undocumented, unstable detail of the upstream script (it
+# has switched between the one-line `.list` format and the deb822 `.sources`
+# format), and copying that file between stages breaks silently when it
+# changes. Only the shared library is needed at runtime (not the -dev
+# headers, which are only required when building the `mariadb` wheel in the
+# builder stage above).
+RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget gnupg \
+    && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
+    && chmod +x mariadb_repo_setup \
+    && ./mariadb_repo_setup --mariadb-server-version="mariadb-10.11.18" \
+    && apt-get update && apt-get install -y libmariadb3 \
+    && rm -f mariadb_repo_setup
 
 
 


### PR DESCRIPTION
## Summary
- `.github/workflows/docker-pipeline.yaml` currently fails on every PR with `##[error]This request has been automatically failed because it uses a deprecated version of 'actions/upload-artifact: v3'.` This is blocking the `build`/`compose` checks on unrelated in-flight PRs (e.g. #71), since the failure has nothing to do with those PRs' actual content.
- This PR bumps `actions/upload-artifact@v3` → `@v4` (in the `build` job) and `actions/download-artifact@v3` → `@v4` (in the `compose` job).
- Reviewed the other actions used in the file (`actions/checkout@v4`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v5`, `isbang/compose-action@v1.5.1`) — none of these are currently deprecated, so they were left unchanged. Change is minimal and targeted; no job/step restructuring.

Note: there's a separate, larger in-flight PR (#70) that replaces this whole file with a new `ci.yml`. That PR is still blocked on other issues, so this is a narrow standalone fix to unblock `main`'s CI in the meantime.

## Additional fix: broken `mariadb-connector-c` Dockerfile stage

After the artifact-action bump, the `build` job's `docker build` still failed, with a real, pre-existing bug in the repo's own `Dockerfile` (and `Dockerfile_with_Proxy`, which has the identical pattern):

```
#17 7.790 update-alternatives: error: no alternatives for my.cnf
#20 ERROR: failed to calculate checksum of ref ...: "/etc/apt/sources.list.d/mariadb.list": not found
```

Root causes (confirmed by fetching and inspecting the actual `mariadb_repo_setup` script and by test-building locally):
1. The separate `mariadb-connector-c` build stage ran MariaDB's `mariadb_repo_setup` script and the `runtime` stage tried to `COPY --from=mariadb-connector-c /etc/apt/sources.list.d/mariadb.list ...`. That script has since changed upstream to write a deb822-style `/etc/apt/sources.list.d/mariadb.sources` file by default instead of the old one-line `.list` file, so the `COPY` failed with "not found". This filename/format is an undocumented internal detail of the script, so copying it across build stages is inherently fragile.
2. Separately, the `builder` stage (which builds the `mariadb` Python wheel via Poetry) never installed MariaDB Connector/C dev headers at all. This went unnoticed because it's masked by the same bug — the `mariadb` PyPI package ships no Linux wheels (only Windows), so on Linux it always builds from the sdist, which needs `mariadb_config` on `PATH` at build time.
3. While fixing this, also found that the pinned version `--mariadb-server-version="mariadb-10.6"` (and even the fully-qualified `10.6.27`) fails `mariadb_repo_setup`'s own version-verification step for these particular stages, because `builder`/`runtime` are `python:3.11.7` (Debian bookworm), not `ubuntu:22.04` — and MariaDB no longer publishes a `10.6.x` apt repo for Debian bookworm (only for some other distros). Verified `10.11.18` has a bookworm repo and passes the script's verification.

Fix: removed the separate `mariadb-connector-c` stage entirely and instead run the full `wget`/`mariadb_repo_setup`/`apt-get install` sequence directly in each stage that needs it:
- `builder`: installs `libmariadb3` + `libmariadb-dev` (dev headers needed to build the `mariadb` wheel).
- `runtime`: installs `libmariadb3` only (just the shared library needed to load that wheel at runtime).
- Bumped the pinned MariaDB series to the full version `10.11.18`.
- Applied the identical fix to `Dockerfile_with_Proxy` for consistency (same broken pattern, not used by CI but kept in sync).

This avoids depending on an undocumented/unstable third-party script output format ever again, at the cost of duplicating a few `apt-get` lines across stages — a good trade for robustness.

## Additional fix: missing compose config/env setup for the `compose` job

Once `build` started passing, the `compose` job failed at the `docker compose config -o docker-compose-filled.yml` step with:
```
error while interpolating volumes.embedding_model_folder.driver_opts.device: required variable EMBEDDING_MODEL_FOLDER_PATH is missing a value: error
```

`docker-compose.yml` requires five gitignored `env_file` entries (`.env`, `settings/.app.env`, `settings/.retrieval.env`, `settings/.mariadb.env`, `settings/.model.env`) and two host-path env vars (`CHAT_MODEL_FOLDER_PATH`, `EMBEDDING_MODEL_FOLDER_PATH`), none of which exist in a fresh checkout. This was likely always broken — it was previously masked by the deprecated-artifact-action failure happening first, so `compose` never actually ran before now.

Fix: added a "Set up dummy config for compose smoke test" step to the `compose` job, before `Docker Compose Config`, that creates `settings/` and two throwaway model directories, writes minimal dummy `KEY=VALUE` pairs into each required env file (var names matched to files per the `README.md` documentation — e.g. `MARIADB_*` → `settings/.mariadb.env`, `CHAT_MODEL_*`/`EMBEDDING_MODEL_*` → `settings/.model.env`), and exports `CHAT_MODEL_FOLDER_PATH`/`EMBEDDING_MODEL_FOLDER_PATH` via `$GITHUB_ENV` pointing at those throwaway directories. Verified locally with a real `docker compose config` run (Docker Compose v2.40.3) that this produces a valid filled-in compose file.

## Test plan
- [x] Locally verified with a real `docker build` (with a live Docker daemon) that `mariadb_repo_setup --mariadb-server-version="mariadb-10.11.18"` succeeds inside the `python:3.11.7` (Debian bookworm) base image, writes `mariadb.sources` (confirming the root-cause theory), and that `apt-get install libmariadb3 libmariadb-dev` succeeds.
- [x] Locally verified (real Docker Compose v2.40.3) that with the new dummy-config step's env files and vars in place, `docker compose config -o docker-compose-filled.yml` succeeds and produces a fully-interpolated compose file.
- [x] I could not run the *complete* end-to-end `docker build` (including the full `poetry install` / `llama-cpp-python` compile / final image assembly) to 100% completion in my sandbox in the time available, and cannot run GitHub Actions myself. **Real verification happens once GitHub Actions runs this workflow on this PR** — please check `gh pr checks 72` (or the Checks tab) after pushing to confirm the `build` and `compose` jobs now pass.
