### PR TITLE
Add Docker build caching (issue #57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
           push: false
           load: true
           tags: dora-backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Docker Compose Config
         run: |


### PR DESCRIPTION
Closes #57

## Summary
Adds Docker build layer caching to the `docker-integration` CI job in `.github/workflows/ci.yml`.

The job already builds the image via `docker/build-push-action@v6` with Buildx, but with `push: false` — the image is never pushed to a registry. That rules out the inline cache backend (`BUILDKIT_INLINE_CACHE=1`) referenced in the issue, since inline cache requires the image (with embedded cache metadata) to be pushed somewhere it can later be pulled from.

Instead, this uses the GitHub Actions cache backend (`cache-from: type=gha`, `cache-to: type=gha,mode=max`), which is the recommended approach for `docker/build-push-action` when not pushing to a registry. It stores build layer cache in the GitHub Actions cache service, so subsequent CI runs can reuse unchanged layers instead of rebuilding from scratch.

No Dockerfile changes were needed — BuildKit is already in use via `docker/setup-buildx-action@v3`.

## Test plan
- [x] CI passes on this PR (docker-integration job builds successfully with cache-from/cache-to configured)
- [ ] A second CI run on this PR (e.g. after a trivial follow-up commit) shows a faster/cached build, confirming the cache is populated and reused