### PR TITLE
Separate collection_name from user_id in Chatbot (issue #63)

### DIFF
--- a/app.py
+++ b/app.py
@@ -392,7 +392,7 @@ def prompt() -> Response:
         future = executor.futures.pop(f"process_files_{session_id}")
         future.result()
     message = str(get_property("prompt"))
-    chatbot = Chatbot(user_id=session_id)
+    chatbot = Chatbot(user_id=session_id, collection_name=session_id)
     prompt_response = PromptResponse(
         message="Prompt result is found under the result key.",
         error="",

--- a/chatdoc/chatbot.py
+++ b/chatdoc/chatbot.py
@@ -23,10 +23,22 @@ class Chatbot:
     def __init__(
         self,
         user_id: str,
+        collection_name: str | None = None,
     ):
+        """
+        Args:
+            user_id (str): Identifies the chat history for this user/session. Used
+                exclusively to key the `SQLChatMessageHistory` conversation memory.
+            collection_name (str | None): Identifies the vector store collection
+                where the documents for this chat are stored. Used exclusively to
+                select the `VectorDatabase` collection. Defaults to `user_id` when
+                not provided, so a single caller-supplied identifier can still be
+                used for both without breaking existing behavior.
+        """
         self.user_id = user_id
+        self.collection_name = collection_name if collection_name is not None else user_id
         self.embedding_fn = EmbeddingFactory().create()
-        self.vector_db = VectorDatabase(self.user_id, self.embedding_fn)
+        self.vector_db = VectorDatabase(self.collection_name, self.embedding_fn)
         self.memory_db = SQLAlchemyChatMessageHistory(self.user_id, Utils.get_env_variable("CHAT_HISTORY_CONNECTION_STRING"))
         self.memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True, output_key="answer")
         self.chat_model: BaseChatModel = ChatModel().chat_model

--- a/tests/chatbot_test.py
+++ b/tests/chatbot_test.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from chatdoc.chatbot import Chatbot
+
+
+@pytest.fixture(name="mock_dependencies")
+def fixture_mock_dependencies(monkeypatch):
+    """
+    Patches every external dependency that `Chatbot.__init__` touches so that
+    tests can assert on how `user_id` and `collection_name` are routed without
+    needing a real embedding model, vector store, chat model, or database
+    connection.
+
+    Returns:
+        dict: The patched classes/objects, keyed by name, so tests can assert
+            on how they were called.
+    """
+    monkeypatch.setenv("CHAT_HISTORY_CONNECTION_STRING", "sqlite:///:memory:")
+
+    with patch("chatdoc.chatbot.EmbeddingFactory") as mock_embedding_factory, patch(
+        "chatdoc.chatbot.VectorDatabase"
+    ) as mock_vector_database, patch(
+        "chatdoc.chatbot.SQLAlchemyChatMessageHistory"
+    ) as mock_sql_chat_message_history, patch(
+        "chatdoc.chatbot.ChatModel"
+    ) as mock_chat_model, patch(
+        "chatdoc.chatbot.ConversationalRetrievalChain"
+    ) as mock_conversational_retrieval_chain:
+        mock_embedding_factory.return_value.create.return_value = MagicMock()
+        mock_vector_database.return_value = MagicMock()
+        mock_sql_chat_message_history.return_value = MagicMock(messages=[])
+        mock_chat_model.return_value.chat_model = MagicMock()
+        mock_conversational_retrieval_chain.from_llm.return_value = MagicMock()
+        yield {
+            "EmbeddingFactory": mock_embedding_factory,
+            "VectorDatabase": mock_vector_database,
+            "SQLAlchemyChatMessageHistory": mock_sql_chat_message_history,
+            "ChatModel": mock_chat_model,
+            "ConversationalRetrievalChain": mock_conversational_retrieval_chain,
+        }
+
+
+def test_collection_name_defaults_to_user_id(mock_dependencies):
+    """
+    When no `collection_name` is supplied, the `Chatbot` should fall back to
+    using `user_id` for both the chat history session and the vector store
+    collection, preserving the previous behavior for existing callers.
+    """
+    chatbot = Chatbot(user_id="user-123")
+
+    assert chatbot.user_id == "user-123"
+    assert chatbot.collection_name == "user-123"
+    mock_dependencies["VectorDatabase"].assert_called_once_with(
+        "user-123", mock_dependencies["EmbeddingFactory"].return_value.create.return_value
+    )
+    mock_dependencies["SQLAlchemyChatMessageHistory"].assert_called_once_with(
+        "user-123", "sqlite:///:memory:"
+    )
+
+
+def test_collection_name_used_independently_from_user_id(mock_dependencies):
+    """
+    When `collection_name` is supplied explicitly and differs from `user_id`,
+    the vector store should be keyed by `collection_name` while the chat
+    history should still be keyed by `user_id`.
+    """
+    chatbot = Chatbot(user_id="user-123", collection_name="collection-abc")
+
+    assert chatbot.user_id == "user-123"
+    assert chatbot.collection_name == "collection-abc"
+    mock_dependencies["VectorDatabase"].assert_called_once_with(
+        "collection-abc", mock_dependencies["EmbeddingFactory"].return_value.create.return_value
+    )
+    mock_dependencies["SQLAlchemyChatMessageHistory"].assert_called_once_with(
+        "user-123", "sqlite:///:memory:"
+    )


### PR DESCRIPTION
Closes #63

## Summary
`Chatbot` previously used `user_id` for two unrelated purposes:
- keying the `SQLChatMessageHistory` conversation memory
- selecting the `VectorDatabase` (Chroma) collection

This change introduces a separate `collection_name` parameter on `Chatbot.__init__`:
- `user_id` is now used exclusively for chat history.
- `collection_name` is now used exclusively for vector store collection selection.
- `collection_name` defaults to `user_id` when not supplied, so existing callers that only pass `user_id` keep working unchanged.
- The `/prompt` route in `app.py` (the only current call site) now passes both explicitly.

## Test plan
- [x] Added `tests/chatbot_test.py`, mocking out `EmbeddingFactory`, `VectorDatabase`, `SQLChatMessageHistory`, `ChatModel`, and `ConversationalRetrievalChain`, asserting that:
  - `collection_name` defaults to `user_id` when omitted.
  - `VectorDatabase` and `SQLChatMessageHistory` are keyed independently when `collection_name` differs from `user_id`.
- [ ] CI (pytest) — local `poetry install` fails in this sandbox because `chroma-hnswlib` needs a C++ compiler unavailable here, so verification relies on GitHub Actions.