### PR TITLE
Refactor primary chat endpoint to async (issue #66)

### DIFF
--- a/app.py
+++ b/app.py
@@ -371,7 +371,7 @@ async def delete_file() -> Response:
 
 @app.route("/prompt", methods=["POST"])
 @swag_from("swagger/prompt.yml")
-def prompt() -> Response:
+async def prompt() -> Response:
     """
     This function handles the prompt request from the client.
 
@@ -396,7 +396,7 @@ def prompt() -> Response:
     prompt_response = PromptResponse(
         message="Prompt result is found under the result key.",
         error="",
-        result=chatbot.send_prompt(message),
+        result=await chatbot.send_prompt(message),
     )
     return make_response(prompt_response, 200)
 

--- a/chatdoc/chatbot.py
+++ b/chatdoc/chatbot.py
@@ -39,11 +39,16 @@ class Chatbot:
         self.chat_history = self.memory_db.messages
         self.last_n_messages = int(os_environ.get("LAST_N_MESSAGES", 5))
 
-    def send_prompt(self, prompt: str) -> dict[str, Any]:
+    async def send_prompt(self, prompt: str) -> dict[str, Any]:
         """
         Method to send a prompt to the chatbot
+
+        Uses the chain's async `acall` so that the (slow) LLM completion and
+        retrieval calls don't block the Flask worker's event loop.
         """
-        result = self.chatQA({"question": prompt, "chat_history": self.chat_history[-self.last_n_messages :]})
+        result = await self.chatQA.acall(
+            {"question": prompt, "chat_history": self.chat_history[-self.last_n_messages :]}
+        )
         citations = Citations(result["source_documents"])
         result["citations"] = citations.__dict__()
         for message in result["chat_history"]:


### PR DESCRIPTION
Closes #66

## Scope

Issue #66 ("Refactor to async") had no description, so I scoped this conservatively to the highest-value, most reviewable change: the `/prompt` endpoint, which is the main blocking bottleneck for a chatbot backend (an LLM completion call plus vector-store retrieval per request).

### What changed
- `chatdoc/chatbot.py`: `Chatbot.send_prompt` is now `async def` and calls `self.chatQA.acall(...)` instead of `self.chatQA(...)`. `ConversationalRetrievalChain` (langchain 0.0.353 / langchain-core 0.1.4, already pinned in `pyproject.toml`) implements a real `_acall`/`_aget_docs` for this chain (verified in the installed package source, not just a thread-pool wrapper around the sync path), so this is genuine async I/O, not just cosmetic.
- `app.py`: the `/prompt` route handler is now `async def` and awaits `chatbot.send_prompt(...)`. Flask's `async` extra (already a dependency) runs this natively via the ASGI/asyncio adapter.

### What was intentionally left synchronous, and why
- **SQLAlchemy calls** (`SQLChatMessageHistory.add_message`, `ExperimentSessionMethods.*`, `get_chat_history`, `clear_chat_history`, `get_sessions`): these use the sync SQLAlchemy engine. Introducing async SQLAlchemy would mean a new engine/session setup and a new dependency, which is out of scope for this issue. Per Flask's async support, calling sync code from inside an `async def` view still works correctly (it just runs synchronously within that request's task), so no behavior changes here — only the LLM call path was moved to genuinely non-blocking I/O.
- **`/upload_files`, `/delete_file`**: already `async def` and already call the async `ServerMethods` methods (`save_files_to_tmp`, `save_files_to_vector_db`, `delete_docs_from_vector_db`) — no changes needed.
- **`/identify`, `/get_chat_history`, `/clear_chat_history`, `/get_sessions`, `/upload_files_json`, `/get_file_id_mappings`**: left as sync routes. These are fast, simple DB-record/metadata operations, not slow LLM/document-processing work, so converting them wouldn't reduce worker blocking meaningfully and would just expand the diff.
- Did not touch `ServerMethods` document-loading internals beyond what was already async.

### Testing
No existing tests call `Chatbot.send_prompt` or the `/prompt` route directly (checked `tests/`), so no test changes were required and `pytest-asyncio` was not added. Verified via `ast.parse` locally that both changed files are syntactically valid (local `poetry install` fails here due to an unrelated chroma-hnswlib build issue in this environment — relying on CI for the real test run).