### PR TITLE
Use per-module loggers instead of passing Logger instances (issue #53)

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,7 +71,7 @@ match current_env:
         raise ValueError("Invalid environment variable set for CURRENT_ENV")
 
 app.secret_key = str(uuid.uuid4())
-sm_app = ServerMethods(app)
+sm_app = ServerMethods()
 executor = Executor(app)
 
 Basic = str | int | float | bool
@@ -216,7 +216,7 @@ def identify() -> Response:
         identify_response = IdentifyResponse(
             message=f"Welcome new user: {identity['sessionId']} !", error="", **identity
         )
-    ExperimentSessionMethods.add_new_session(identity["sessionId"], app.logger)
+    ExperimentSessionMethods.add_new_session(identity["sessionId"])
     session.update(identity)
     response = make_response(identify_response, 200)
     return response
@@ -451,7 +451,7 @@ def get_sessions() -> Response:
     Returns:
         tuple: A tuple containing the response message and the HTTP status code.
     """
-    sessions = ExperimentSessionMethods.retrieve_sessions(app.logger)
+    sessions = ExperimentSessionMethods.retrieve_sessions()
     response_message = SessionQueryResponse(
         message="Sessions successfully retrieved!",
         error="",

--- a/chatdoc/doc_loader/document_loader.py
+++ b/chatdoc/doc_loader/document_loader.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from logging import Logger
+import logging
 from typing import Iterator
 from tqdm.auto import tqdm
 import os
@@ -8,6 +8,8 @@ from langchain.text_splitter import NLTKTextSplitter, RecursiveCharacterTextSpli
 from langchain.schema import Document
 
 from chatdoc.doc_loader.document_loader_factory import DocumentLoaderFactory, BaseLoader
+
+logger = logging.getLogger(__name__)
 
 
 class DocumentLoader:
@@ -28,11 +30,8 @@ class DocumentLoader:
 
     """
 
-    def __init__(
-        self, document_dict: dict[str, Path], loader_factory: DocumentLoaderFactory, logger: Logger | None = None
-    ):
+    def __init__(self, document_dict: dict[str, Path], loader_factory: DocumentLoaderFactory):
         self.loader_factory = loader_factory
-        self.logger = logger if logger else Logger("DocumentLoader")
         self.loaders_dict: dict[str, BaseLoader] = self.initialize_loaders(document_dict)
         self.document_iterators_dict: dict[str, Iterator[Document]] = self.map_document_iterators()
         self.text_splitter: TextSplitter = self.load_token_text_splitter()
@@ -92,18 +91,18 @@ class DocumentLoader:
         """
         if "CHUNK_SIZE" in os.environ:
             chunk_size = int(os.environ["CHUNK_SIZE"])
-            self.logger.info(msg=f"Using chunk size of {chunk_size}")
+            logger.info(msg=f"Using chunk size of {chunk_size}")
         else:
-            self.logger.info(msg="No chunk size specified, defaulting to 1000")
+            logger.info(msg="No chunk size specified, defaulting to 1000")
             chunk_size = 1000
         if "CHUNK_OVERLAP" in os.environ:
             chunk_overlap = int(os.environ["CHUNK_OVERLAP"])
-            self.logger.info(msg=f"Using chunk overlap of {chunk_overlap} tokens")
+            logger.info(msg=f"Using chunk overlap of {chunk_overlap} tokens")
         else:
-            self.logger.info(msg="No chunk overlap specified, defaulting to 0")
+            logger.info(msg="No chunk overlap specified, defaulting to 0")
             chunk_overlap = 0
         splitter_type = os.environ.get("TEXT_SPLITTER_TYPE", "character")
         if splitter_type == "sentence":
-            self.logger.info(msg="Using sentence-based tokenization (NLTKTextSplitter)")
+            logger.info(msg="Using sentence-based tokenization (NLTKTextSplitter)")
             return NLTKTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
         return RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)

--- a/server_modules/methods.py
+++ b/server_modules/methods.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from typing import Any
 from tqdm.auto import tqdm
 
-from flask import Flask
 import sqlalchemy
 from sqlalchemy.orm import DeclarativeBase
 from werkzeug.datastructures import FileStorage
@@ -19,6 +18,8 @@ from chatdoc.embed.embedding_factory import EmbeddingFactory
 from chatdoc.utils import Utils
 from server_modules.database import create_all_tables, session_scope
 from server_modules.models import FinalAnswerModel, ChatHistoryModel
+
+logger = logging.getLogger(__name__)
 
 
 def create_tmp_dir(session_id: str) -> Path:
@@ -53,9 +54,6 @@ class ServerMethods:
     Class representing server methods for file processing and document handling.
     """
 
-    def __init__(self, app: Flask):
-        self.app = app
-
     FileToPathMapping = dict[str, Path]
     OriginalFileMapping = dict[str, str]
 
@@ -73,7 +71,7 @@ class ServerMethods:
             A tuple containing the original file names and the full file paths.
         """
         dir_path = create_tmp_dir(session_id=session_id)
-        self.app.logger.info(f"Created temporary directory for session {session_id}")
+        logger.info(f"Created temporary directory for session {session_id}")
         original_name_dict: dict[str, str] = {}
         full_document_dict: dict[str, Path] = {}
         for (
@@ -103,7 +101,7 @@ class ServerMethods:
         embedding_fn = EmbeddingFactory().create()
         vector_db = VectorDatabase(user_id, embedding_fn)
         loader_factory = DocumentLoaderFactory()
-        document_loader = DocumentLoader(file_dict, loader_factory, self.app.logger)
+        document_loader = DocumentLoader(file_dict, loader_factory)
         file_id_mapping = {}
         for filename in tqdm(file_dict.keys(), desc="Processing files"):
             document_iterator = document_loader.document_iterators_dict[filename]
@@ -111,11 +109,11 @@ class ServerMethods:
             document_ids = await vector_db.add_documents(documents)
             file_id_mapping[filename] = document_ids
         if delete_tmp_dir(user_id):
-            self.app.logger.info(
+            logger.info(
                 f"Cleaned up temporary directory for session {user_id}"
             )
         else:
-            self.app.logger.error(
+            logger.error(
                 f"Failed to clean up temporary directory for session {user_id}"
             )
         return file_id_mapping
@@ -170,7 +168,7 @@ class ExperimentSessionMethods:
         return ExperimentSessionMethods.__parse_dates(rows)
 
     @staticmethod
-    def add_new_session(session_id: str, logger: logging.Logger) -> None:
+    def add_new_session(session_id: str) -> None:
         """
         Add a new record to the final_answer table when the user starts a new session
         """
@@ -209,7 +207,6 @@ class ExperimentSessionMethods:
         session_id: str,
         original_answer: dict,
         edited_answer: dict,
-        logger: logging.Logger,
     ) -> None:
         """
         Update the final_answer table with the original and edited answers
@@ -256,7 +253,7 @@ class ExperimentSessionMethods:
             session.execute(update_message_count)
 
     @staticmethod
-    def retrieve_sessions(logger: logging.Logger) -> list[dict[str, Any]]:
+    def retrieve_sessions() -> list[dict[str, Any]]:
         """
         Get all the sessions from the final_answer table
         """
@@ -268,7 +265,7 @@ class ExperimentSessionMethods:
         return sessions
 
     @staticmethod
-    def retrieve_chat_history(logger: logging.Logger) -> list[dict[str, Any]]:
+    def retrieve_chat_history() -> list[dict[str, Any]]:
         """
         Get all the chat history from the chat_history table
         """

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 
 import pytest
@@ -123,12 +122,11 @@ def test_experiment_session_lifecycle(env_connection_strings: None) -> None:
     """
     from server_modules.methods import ExperimentSessionMethods
 
-    logger = logging.getLogger("test")
     session_id = "session-123"
 
-    ExperimentSessionMethods.add_new_session(session_id, logger)
+    ExperimentSessionMethods.add_new_session(session_id)
 
-    sessions = ExperimentSessionMethods.retrieve_sessions(logger)
+    sessions = ExperimentSessionMethods.retrieve_sessions()
     assert len(sessions) == 1
     assert sessions[0]["session_id"] == session_id
     assert sessions[0]["number_of_messages"] == -1
@@ -148,10 +146,10 @@ def test_experiment_session_lifecycle(env_connection_strings: None) -> None:
         )
 
     ExperimentSessionMethods.update_session(
-        session_id, {"original": True}, {"edited": True}, logger
+        session_id, {"original": True}, {"edited": True}
     )
 
-    sessions = ExperimentSessionMethods.retrieve_sessions(logger)
+    sessions = ExperimentSessionMethods.retrieve_sessions()
     assert len(sessions) == 1
     assert sessions[0]["number_of_messages"] == 2
     assert sessions[0]["original_answer"] == {"original": True}
@@ -159,5 +157,5 @@ def test_experiment_session_lifecycle(env_connection_strings: None) -> None:
 
     with pytest.raises(ValueError):
         ExperimentSessionMethods.update_session(
-            "unknown-session", {}, {}, logger
+            "unknown-session", {}, {}
         )

--- a/tests/document_loader_test.py
+++ b/tests/document_loader_test.py
@@ -1,4 +1,3 @@
-from logging import Logger
 from pathlib import Path
 from typing import Iterator
 from unittest.mock import MagicMock
@@ -104,9 +103,7 @@ def _bare_document_loader() -> DocumentLoader:
     Builds a DocumentLoader instance without running __init__, so that
     load_token_text_splitter can be tested in isolation.
     """
-    instance = object.__new__(DocumentLoader)
-    instance.logger = Logger("test_document_loader")
-    return instance
+    return object.__new__(DocumentLoader)
 
 
 def test_load_token_text_splitter_defaults_to_character(monkeypatch):


### PR DESCRIPTION
Closes #53

## Summary

Previously, `logging.Logger` instances were manually threaded through constructors and static methods (`DocumentLoader.__init__`, `ServerMethods` via `self.app.logger`, and `ExperimentSessionMethods.add_new_session` / `update_session` / `retrieve_sessions` / `retrieve_chat_history`), requiring every caller to obtain and pass a logger along.

This PR replaces those explicit logger parameters with per-module loggers obtained via `logging.getLogger(__name__)`, so each module manages its own logger without any caller involvement:

- `chatdoc/doc_loader/document_loader.py`: removed the `logger` constructor parameter and `self.logger` attribute; uses a module-level `logger`.
- `server_modules/methods.py`: `ServerMethods` no longer needs the Flask `app` just to reach `app.logger` (its `__init__`/`app` param is removed since it had no other use); `ExperimentSessionMethods` static methods no longer take a `logger` argument.
- `app.py`: updated call sites (`ServerMethods()`, `ExperimentSessionMethods.add_new_session(...)`, `ExperimentSessionMethods.retrieve_sessions()`) to match.
- `tests/document_loader_test.py`: simplified the bare-instance test helper since `DocumentLoader` no longer carries a `self.logger` attribute.

The existing `dictConfig`-based logging setup (`server_modules.set_logging_config`, added for issue #33) configures the root logger's handlers/formatters, so module-level loggers created via `getLogger(__name__)` still write through the same console/file handlers via normal logger propagation — no changes were needed there.

## Test plan
- [ ] CI (`pytest tests/`) passes
- [x] `python -m py_compile` on all touched files