### PR TITLE
Add Chroma VectorDB service to docker-compose (issue #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Make sure to set all the environment variables like:
 - `CHAT_MODEL_NAME`: the name of the chat model (e.g. gpt-turbo-3.5)
 - `EMBEDDING_MODEL_VENDOR_NAME`: the name of the embeddings model vendor [openai, local, huggingface]
 - `EMBEDDING_MODEL_NAME`: the name of the embeddings model (e.g. text-embedding-ada-002)
-- `CURRENT_ENV`: the current environment [DEV, TST, PROD]. In `DEV` a CORS wrapper is applied to the Flask-server, but not in `TST` or `PROD`. In `PROD`, the server will connect to a defined remote endpoint for the Chroma Vector DB, but in `DEV` and `TST`, it will make use of a persistent client in Python.
+- `CURRENT_ENV`: the current environment [DEV, TST, PROD]. In `DEV` a CORS wrapper is applied to the Flask-server, but not in `TST` or `PROD`. In `PROD`, the server will connect to a Chroma Vector DB server over HTTP (see `CHROMA_SERVER_HOST` and `CHROMA_SERVER_PORT` below), but in `DEV` and `TST`, it will make use of a persistent client in Python.
+- `CHROMA_SERVER_HOST`: the hostname of the Chroma Vector DB server to connect to when `CURRENT_ENV=PROD`; defaults to `dora-chromadb` (the service name in `docker-compose.yml`).
+- `CHROMA_SERVER_PORT`: the port of the Chroma Vector DB server to connect to when `CURRENT_ENV=PROD`; defaults to `8000`.
 - `CHAT_MODEL_FOLDER_PATH`: the path to the folder of local chat models
 - `EMBEDDING_MODEL_FOLDER_PATH`: the path to the folder of local embedding models
 - `OPENAI_API_KEY`: an OpenAI API key to use an OpenAI model specified in `CHAT_MODEL_NAME`

--- a/chatdoc/vector_db.py
+++ b/chatdoc/vector_db.py
@@ -8,7 +8,7 @@ from langchain.schema import Document
 from langchain.vectorstores.chroma import Chroma
 from langchain_core.vectorstores import VectorStoreRetriever
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
-from chromadb import PersistentClient
+from chromadb import HttpClient, PersistentClient
 from chromadb.api import ClientAPI
 
 
@@ -89,9 +89,17 @@ class VectorDatabase:
             case "DEV" | "TST":
                 self._chroma_db_client = PersistentClient()
             case "PROD":
-                # Connect to ChromaDB in the cloud
-                # Add code here to connect to ChromaDB in the cloud
-                raise NotImplementedError("ChromaDB in the cloud not implemented yet")
+                # Connect to the ChromaDB server (e.g. the `dora-chromadb`
+                # service in docker-compose.yml) over HTTP.
+                chroma_server_host = os.environ.get(
+                    "CHROMA_SERVER_HOST", "dora-chromadb"
+                )
+                chroma_server_port = int(
+                    os.environ.get("CHROMA_SERVER_PORT", "8000")
+                )
+                self._chroma_db_client = HttpClient(
+                    host=chroma_server_host, port=chroma_server_port
+                )
             case _:
                 raise ValueError("Invalid DORA environment")
         return self._chroma_db_client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,19 @@ services:
       kompose.service.type: nodeport
       kompose.volume.type: hostPath
 
+  dora-chromadb:
+    image: chromadb/chroma:latest
+    ports:
+      - "8001:8000"
+    volumes:
+      - chroma_data:/data
+    environment:
+      - IS_PERSISTENT=TRUE
+      - ANONYMIZED_TELEMETRY=FALSE
+    labels:
+      kompose.service.type: nodeport
+      kompose.volume.type: hostPath
+
   dora-backend:
     image: docker.io/library/dora-backend:latest
     build:
@@ -37,12 +50,16 @@ services:
         required: true
       - path: "./settings/.model.env"
         required: true
+    environment:
+      - CHROMA_SERVER_HOST=${CHROMA_SERVER_HOST:-dora-chromadb}
+      - CHROMA_SERVER_PORT=${CHROMA_SERVER_PORT:-8000}
     volumes:
       - logging_file_dir:/app/logs
       - chat_model_folder:/models/chat_models
       - embedding_model_folder:/models/embedding_model
     depends_on:
       - dora-mariadb
+      - dora-chromadb
     labels:
       kompose.service.type: nodeport
       kompose.volume.type: hostPath
@@ -51,6 +68,7 @@ services:
 volumes:
   logging_file_dir:
   mariadb_data:
+  chroma_data:
   chat_model_folder:
     driver: local
     driver_opts:

--- a/tests/vector_db_test.py
+++ b/tests/vector_db_test.py
@@ -1,0 +1,83 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from chatdoc.vector_db import VectorDatabase
+
+
+@pytest.fixture(name="mock_embedding_fn")
+def mock_embedding_fn_fixture():
+    """
+    Returns a mock embedding function to be used when instantiating a
+    `VectorDatabase` without hitting a real embedding model.
+    """
+    return MagicMock()
+
+
+@patch("chatdoc.vector_db.Chroma")
+@patch("chatdoc.vector_db.PersistentClient")
+def test_chroma_client_dev_uses_persistent_client(
+    mock_persistent_client, mock_chroma, mock_embedding_fn, monkeypatch
+):
+    """
+    In `DEV`/`TST` environments the vector database should use a local
+    `PersistentClient` rather than connecting to a remote Chroma server.
+    """
+    monkeypatch.setenv("CURRENT_ENV", "DEV")
+    mock_persistent_client.return_value = MagicMock()
+
+    vector_db = VectorDatabase(collection_name="test", embedding_fn=mock_embedding_fn)
+
+    assert vector_db.chroma_client is mock_persistent_client.return_value
+    mock_persistent_client.assert_called_once()
+
+
+@patch("chatdoc.vector_db.Chroma")
+@patch("chatdoc.vector_db.HttpClient")
+def test_chroma_client_prod_uses_http_client(
+    mock_http_client, mock_chroma, mock_embedding_fn, monkeypatch
+):
+    """
+    In `PROD`, the vector database should connect to the Chroma server (e.g.
+    the `dora-chromadb` docker-compose service) over HTTP using
+    `CHROMA_SERVER_HOST`/`CHROMA_SERVER_PORT`.
+    """
+    monkeypatch.setenv("CURRENT_ENV", "PROD")
+    monkeypatch.setenv("CHROMA_SERVER_HOST", "some-chroma-host")
+    monkeypatch.setenv("CHROMA_SERVER_PORT", "1234")
+    mock_http_client.return_value = MagicMock()
+
+    vector_db = VectorDatabase(collection_name="test", embedding_fn=mock_embedding_fn)
+
+    assert vector_db.chroma_client is mock_http_client.return_value
+    mock_http_client.assert_called_once_with(host="some-chroma-host", port=1234)
+
+
+@patch("chatdoc.vector_db.Chroma")
+@patch("chatdoc.vector_db.HttpClient")
+def test_chroma_client_prod_uses_default_host_and_port(
+    mock_http_client, mock_chroma, mock_embedding_fn, monkeypatch
+):
+    """
+    When `CHROMA_SERVER_HOST`/`CHROMA_SERVER_PORT` are not set, sensible
+    defaults matching the `dora-chromadb` docker-compose service should be
+    used.
+    """
+    monkeypatch.setenv("CURRENT_ENV", "PROD")
+    monkeypatch.delenv("CHROMA_SERVER_HOST", raising=False)
+    monkeypatch.delenv("CHROMA_SERVER_PORT", raising=False)
+    mock_http_client.return_value = MagicMock()
+
+    vector_db = VectorDatabase(collection_name="test", embedding_fn=mock_embedding_fn)
+
+    assert vector_db.chroma_client is mock_http_client.return_value
+    mock_http_client.assert_called_once_with(host="dora-chromadb", port=8000)
+
+
+def test_chroma_client_invalid_env_raises(mock_embedding_fn, monkeypatch):
+    """
+    An invalid `CURRENT_ENV` value should raise a `ValueError`.
+    """
+    monkeypatch.setenv("CURRENT_ENV", "INVALID")
+    with pytest.raises(ValueError):
+        VectorDatabase(collection_name="test", embedding_fn=mock_embedding_fn)

--- a/tests/vector_db_test.py
+++ b/tests/vector_db_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, MagicMock
 
 import pytest
+from langchain_core.vectorstores import VectorStore
 
 from chatdoc.vector_db import VectorDatabase
 
@@ -25,6 +26,7 @@ def test_chroma_client_dev_uses_persistent_client(
     """
     monkeypatch.setenv("CURRENT_ENV", "DEV")
     mock_persistent_client.return_value = MagicMock()
+    mock_chroma.return_value = MagicMock(spec=VectorStore)
 
     vector_db = VectorDatabase(collection_name="test", embedding_fn=mock_embedding_fn)
 
@@ -46,6 +48,7 @@ def test_chroma_client_prod_uses_http_client(
     monkeypatch.setenv("CHROMA_SERVER_HOST", "some-chroma-host")
     monkeypatch.setenv("CHROMA_SERVER_PORT", "1234")
     mock_http_client.return_value = MagicMock()
+    mock_chroma.return_value = MagicMock(spec=VectorStore)
 
     vector_db = VectorDatabase(collection_name="test", embedding_fn=mock_embedding_fn)
 
@@ -67,6 +70,7 @@ def test_chroma_client_prod_uses_default_host_and_port(
     monkeypatch.delenv("CHROMA_SERVER_HOST", raising=False)
     monkeypatch.delenv("CHROMA_SERVER_PORT", raising=False)
     mock_http_client.return_value = MagicMock()
+    mock_chroma.return_value = MagicMock(spec=VectorStore)
 
     vector_db = VectorDatabase(collection_name="test", embedding_fn=mock_embedding_fn)
 


### PR DESCRIPTION
Closes #38

## Summary
- Adds a `dora-chromadb` service to `docker-compose.yml` running the official `chromadb/chroma` server image (per https://docs.trychroma.com/deployment#docker), with a persistent named volume (`chroma_data:/data`) and port mapping (`8001:8000`), following the same conventions as the existing `dora-mariadb` service (issue #36).
- Wires up the previously-unimplemented `PROD` branch of `VectorDatabase.chroma_client` (`chatdoc/vector_db.py`) to connect to the Chroma server over HTTP via `chromadb.HttpClient`, instead of raising `NotImplementedError`.
- The HTTP client's host/port are configurable via `CHROMA_SERVER_HOST` / `CHROMA_SERVER_PORT` environment variables, defaulting to the `dora-chromadb` service name and port `8000` — consistent with how other service connection details (e.g. MariaDB) are configured via env vars elsewhere in the codebase. `DEV`/`TST` are unaffected and continue to use the local `PersistentClient`.
- `dora-backend` now `depends_on` `dora-chromadb` and gets the `CHROMA_SERVER_HOST`/`CHROMA_SERVER_PORT` env vars with sensible defaults (via compose `${VAR:-default}` syntax), so no new required settings file is needed and the `docker-integration` CI job (which doesn't set `CURRENT_ENV=PROD`) is unaffected.
- Documented the new environment variables in `README.md`.
- Added `tests/vector_db_test.py` covering the `chroma_client` property for `DEV` (PersistentClient), `PROD` with explicit host/port, `PROD` with defaults, and the invalid-env error case, mocking `chromadb.PersistentClient`/`HttpClient` and `Chroma`.

## Verification
- Validated locally with `docker compose config` and `docker compose up` that the `dora-chromadb` container starts, persists data to the `chroma_data` volume, and responds on `http://localhost:8001/api/v2/heartbeat`.
- Local `poetry install`/`pytest` isn't runnable in this environment (chroma-hnswlib build issue), so correctness of the Python-level test suite is being verified via CI.

## Test plan
- [x] CI `python-tests` job passes (including new `tests/vector_db_test.py`)
- [x] CI `docker-integration` job passes (new `dora-chromadb` container starts alongside `dora-mariadb`/`dora-backend`)