### PR TITLE
Add timestamp to chat messages via custom SQLAlchemy-backed history (issue #47)

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,6 @@ from flask import Flask, request, session, make_response, Response
 from flask_executor import Executor
 from flasgger import Swagger, swag_from
 from langchain_core.messages.base import messages_to_dict
-from langchain_community.chat_message_histories import SQLChatMessageHistory
 from werkzeug.datastructures import FileStorage
 
 # local imports
@@ -32,6 +31,7 @@ from server_modules.class_defs import (
     SessionQueryResponse,
 )
 from chatdoc.chatbot import Chatbot
+from chatdoc.chat_history import SQLAlchemyChatMessageHistory
 from chatdoc.utils import Utils
 
 
@@ -411,7 +411,7 @@ def get_chat_history() -> Response:
         Response: A response object containing the chat history and status code.
     """
     session_id = str(get_property("sessionId"))
-    memory_db = SQLChatMessageHistory(
+    memory_db = SQLAlchemyChatMessageHistory(
         session_id, Utils.get_env_variable("CHAT_HISTORY_CONNECTION_STRING")
     )
     response_message = ChatHistoryResponse(
@@ -432,7 +432,7 @@ def clear_chat_history() -> Response:
         Response: A response object containing the message and status code.
     """
     session_id = str(get_property("sessionId"))
-    memory_db = SQLChatMessageHistory(
+    memory_db = SQLAlchemyChatMessageHistory(
         session_id, Utils.get_env_variable("CHAT_HISTORY_CONNECTION_STRING")
     )
     memory_db.clear()

--- a/chatdoc/chat_history.py
+++ b/chatdoc/chat_history.py
@@ -1,0 +1,70 @@
+import logging
+from typing import List
+
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import BaseMessage, message_to_dict, messages_from_dict
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from server_modules.models import ChatHistoryModel
+
+logger = logging.getLogger(__name__)
+
+
+class SQLAlchemyChatMessageHistory(BaseChatMessageHistory):
+    """
+    Chat message history backed by our own `ChatHistoryModel` SQLAlchemy model
+    (table `message_store`), replacing LangChain's built-in
+    `SQLChatMessageHistory`.
+
+    Storing the messages via our own model (instead of the dynamically
+    generated model LangChain creates internally) lets us persist additional
+    columns - most notably a per-message `timestamp` - alongside each chat
+    message.
+
+    The public interface (`messages`, `add_message`, `clear`) intentionally
+    mirrors `langchain_community.chat_message_histories.SQLChatMessageHistory`
+    so that `Chatbot` (and any other caller) does not need to change.
+    """
+
+    def __init__(self, session_id: str, connection_string: str) -> None:
+        self.session_id = session_id
+        self.connection_string = connection_string
+        self.engine = create_engine(connection_string, echo=False)
+        self.sql_model_class = ChatHistoryModel
+        self._create_table_if_not_exists()
+        self.session_factory = sessionmaker(self.engine)
+
+    def _create_table_if_not_exists(self) -> None:
+        self.sql_model_class.metadata.create_all(self.engine)
+
+    @property
+    def messages(self) -> List[BaseMessage]:  # type: ignore[override]
+        """Retrieve all messages for this session, ordered by insertion/timestamp."""
+        with self.session_factory() as session:
+            records = (
+                session.query(self.sql_model_class)
+                .where(self.sql_model_class.session_id == self.session_id)
+                .order_by(self.sql_model_class.id.asc())
+            )
+            return [messages_from_dict([record.message])[0] for record in records]
+
+    def add_message(self, message: BaseMessage) -> None:
+        """Persist a single message (with its timestamp) to the database."""
+        with self.session_factory() as session:
+            session.add(
+                self.sql_model_class(
+                    session_id=self.session_id,
+                    message=message_to_dict(message),
+                )
+            )
+            session.commit()
+            logger.debug("Persisted message for session_id=%s", self.session_id)
+
+    def clear(self) -> None:
+        """Remove all messages for this session from the database."""
+        with self.session_factory() as session:
+            session.query(self.sql_model_class).filter(
+                self.sql_model_class.session_id == self.session_id
+            ).delete()
+            session.commit()

--- a/chatdoc/chatbot.py
+++ b/chatdoc/chatbot.py
@@ -4,12 +4,12 @@ from typing import Any
 from langchain.chains import ConversationalRetrievalChain
 from langchain.chat_models.base import BaseChatModel
 from langchain.memory import ConversationBufferMemory
-from langchain_community.chat_message_histories import SQLChatMessageHistory
 from langchain_core.messages.base import messages_to_dict
 
 
 from .vector_db import VectorDatabase
 from .citation import Citations
+from .chat_history import SQLAlchemyChatMessageHistory
 from .embed.embedding_factory import EmbeddingFactory
 from .chat_model import ChatModel
 from .utils import Utils
@@ -27,7 +27,7 @@ class Chatbot:
         self.user_id = user_id
         self.embedding_fn = EmbeddingFactory().create()
         self.vector_db = VectorDatabase(self.user_id, self.embedding_fn)
-        self.memory_db = SQLChatMessageHistory(self.user_id, Utils.get_env_variable("CHAT_HISTORY_CONNECTION_STRING"))
+        self.memory_db = SQLAlchemyChatMessageHistory(self.user_id, Utils.get_env_variable("CHAT_HISTORY_CONNECTION_STRING"))
         self.memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True, output_key="answer")
         self.chat_model: BaseChatModel = ChatModel().chat_model
         self.chatQA = ConversationalRetrievalChain.from_llm(  # pylint: disable=invalid-name

--- a/server_modules/models.py
+++ b/server_modules/models.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import JSON, String
+from sqlalchemy import JSON, String, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -30,6 +30,7 @@ class ChatHistoryModel(ChatHistoryBase):
     id: Mapped[int] = mapped_column(primary_key=True)
     session_id: Mapped[str] = mapped_column(String(36))
     message: Mapped[dict[str, Any]] = mapped_column(JSON)
+    timestamp: Mapped[datetime] = mapped_column(server_default=func.now())
 
 
 class FinalAnswerModel(FinalAnswerBase):

--- a/tests/chat_history_test.py
+++ b/tests/chat_history_test.py
@@ -1,0 +1,84 @@
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from sqlalchemy import select
+
+from chatdoc.chat_history import SQLAlchemyChatMessageHistory
+from server_modules.models import ChatHistoryModel
+
+
+@pytest.fixture(name="connection_string")
+def connection_string_fixture(tmp_path):
+    """
+    A file-based SQLite connection string, unique per test, so that multiple
+    `SQLAlchemyChatMessageHistory` instances (each opening their own engine)
+    still share the same underlying database - mirroring how, in production,
+    multiple requests connect to the same chat-history database.
+    """
+    yield f"sqlite:///{tmp_path / 'chat_history.db'}"
+
+
+@pytest.fixture(name="chat_history")
+def chat_history_fixture(connection_string):
+    """
+    Fixture that creates a `SQLAlchemyChatMessageHistory` backed by a
+    temporary SQLite database, isolated per test.
+    """
+    yield SQLAlchemyChatMessageHistory("test-session", connection_string)
+
+
+def test_messages_empty_by_default(chat_history):
+    """
+    A freshly created chat history should have no messages.
+    """
+    assert not chat_history.messages
+
+
+def test_add_message_persists_message(chat_history):
+    """
+    Adding a message should make it retrievable via the `messages` property,
+    preserving type and content.
+    """
+    chat_history.add_message(HumanMessage(content="Hello there"))
+    messages = chat_history.messages
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage)
+    assert messages[0].content == "Hello there"
+
+
+def test_add_message_persists_timestamp(chat_history):
+    """
+    Each persisted message should get a non-null `timestamp` set by the
+    database (server-side default), so message ordering/age can be tracked.
+    """
+    chat_history.add_message(HumanMessage(content="Hello there"))
+    with chat_history.session_factory() as session:
+        record = session.execute(
+            select(ChatHistoryModel).where(ChatHistoryModel.session_id == "test-session")
+        ).scalar_one()
+        assert record.timestamp is not None
+
+
+def test_messages_are_ordered_and_isolated_per_session(chat_history):
+    """
+    Messages should be returned in insertion order, and messages belonging to
+    another session id should not leak in.
+    """
+    other_history = SQLAlchemyChatMessageHistory("other-session", chat_history.connection_string)
+    chat_history.add_message(HumanMessage(content="first"))
+    other_history.add_message(HumanMessage(content="should not appear"))
+    chat_history.add_message(AIMessage(content="second"))
+
+    messages = chat_history.messages
+    assert [message.content for message in messages] == ["first", "second"]
+
+
+def test_clear_removes_all_messages(chat_history):
+    """
+    Clearing the history should remove all messages for that session.
+    """
+    chat_history.add_message(HumanMessage(content="Hello there"))
+    chat_history.add_message(AIMessage(content="Hi!"))
+    assert len(chat_history.messages) == 2
+
+    chat_history.clear()
+    assert not chat_history.messages


### PR DESCRIPTION
Closes #47

## Summary
- Adds a `timestamp` column (server-side default `func.now()`) to `ChatHistoryModel` in `server_modules/models.py`, so every chat message row records when it was persisted.
- Replaces LangChain's built-in `SQLChatMessageHistory` (from `langchain_community.chat_message_histories`) with a new custom `SQLAlchemyChatMessageHistory` (`chatdoc/chat_history.py`) backed directly by our own `ChatHistoryModel`, implementing the same minimal interface (`messages` property, `add_message`, `clear`) LangChain's `BaseChatMessageHistory` expects.
- Updates the two call sites (`chatdoc/chatbot.py`, `app.py`) to use the new class. The public interface consumed by `Chatbot` and the Flask routes is unchanged, so no other call sites needed updates.
- Adds `tests/chat_history_test.py` covering the new class: empty history, adding/retrieving messages, timestamp persistence, per-session isolation/ordering, and clearing history (using a temp file-based SQLite DB, mirroring existing test conventions).

## Notes
- Previously, LangChain's `SQLChatMessageHistory` created its own dynamically-generated table model (with a `Text` message column) rather than using our `ChatHistoryModel` (which declares a `JSON` message column) - despite both targeting the `message_store` table. This PR unifies message persistence onto our own model so the schema (including the new `timestamp` column) is actually the one used at write time.
- Local `poetry install` fails in this environment due to a `chroma-hnswlib` build issue unrelated to this change; tests were verified by installing the project's runtime/test dependencies directly into a cached virtualenv (all 28 tests pass, including the 5 new ones). CI will be the source of truth.

## Test plan
- [x] `pytest tests/chat_history_test.py` - 5/5 pass
- [x] `pytest tests/` - 28/28 pass (in a manually-provisioned venv, since `poetry install` fails locally)
- [ ] CI green