### PR TITLE
Refactor DB classes to SQLAlchemy 2.0 idioms, remove duplication (issue #52)

### DIFF
--- a/server_modules/database.py
+++ b/server_modules/database.py
@@ -1,0 +1,56 @@
+"""
+Shared SQLAlchemy 2.0 engine/session utilities.
+
+This module centralizes engine creation and session handling so that the
+rest of the codebase (e.g. ``server_modules.methods``) does not need to
+repeat ``sqlalchemy.create_engine(...)`` boilerplate for every database
+operation. Engines are cached per connection string so repeated calls reuse
+the same connection pool.
+"""
+
+from contextlib import contextmanager
+from functools import lru_cache
+from typing import Iterator
+
+import sqlalchemy
+from sqlalchemy import Engine
+from sqlalchemy.orm import DeclarativeBase, Session
+
+
+@lru_cache(maxsize=None)
+def get_engine(connection_string: str) -> Engine:
+    """
+    Get a (cached) SQLAlchemy engine for the given connection string.
+
+    Engines are expensive to create and are meant to be reused, so this
+    function caches one engine per unique connection string.
+    """
+    return sqlalchemy.create_engine(connection_string)
+
+
+def create_all_tables(base: type[DeclarativeBase], connection_string: str) -> None:
+    """
+    Create all tables belonging to ``base``'s metadata if they don't exist yet.
+    """
+    engine = get_engine(connection_string)
+    base.metadata.create_all(engine)
+
+
+@contextmanager
+def session_scope(connection_string: str) -> Iterator[Session]:
+    """
+    Provide a transactional session scope bound to the engine for
+    ``connection_string``.
+
+    On successful exit the transaction is committed; on exception it is
+    rolled back. The session is always closed.
+    """
+    session = Session(get_engine(connection_string))
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/server_modules/methods.py
+++ b/server_modules/methods.py
@@ -17,6 +17,7 @@ from chatdoc.doc_loader.document_loader_factory import DocumentLoaderFactory
 from chatdoc.vector_db import VectorDatabase
 from chatdoc.embed.embedding_factory import EmbeddingFactory
 from chatdoc.utils import Utils
+from server_modules.database import create_all_tables, session_scope
 from server_modules.models import FinalAnswerModel, ChatHistoryModel
 
 
@@ -161,13 +162,12 @@ class ExperimentSessionMethods:
         """
         Get all the rows from the given table
         """
-        db_engine = sqlalchemy.create_engine(connection_string)
-        with db_engine.connect() as connection:
-            query = sqlalchemy.select(table_model)
-            result = connection.execute(query)
-            rows = [dict(row._asdict()) for row in result]
-            formatted_rows = ExperimentSessionMethods.__parse_dates(rows)
-            return formatted_rows
+        # Select the underlying Table (not the mapped class) so that rows come
+        # back as plain columns instead of ORM entity instances.
+        query = sqlalchemy.select(table_model.__table__)
+        with session_scope(connection_string) as session:
+            rows = [dict(row) for row in session.execute(query).mappings()]
+        return ExperimentSessionMethods.__parse_dates(rows)
 
     @staticmethod
     def add_new_session(session_id: str, logger: logging.Logger) -> None:
@@ -175,11 +175,9 @@ class ExperimentSessionMethods:
         Add a new record to the final_answer table when the user starts a new session
         """
         logger.info(f"Adding new record for session id: {session_id}")
-        db_engine = sqlalchemy.create_engine(
-            Utils.get_env_variable("FINAL_ANSWER_CONNECTION_STRING")
-        )
-        FinalAnswerModel.metadata.create_all(
-            db_engine
+        connection_string = Utils.get_env_variable("FINAL_ANSWER_CONNECTION_STRING")
+        create_all_tables(
+            FinalAnswerModel, connection_string
         )  # CREATE TABLE IF NOT EXISTS final_answer
         answer_model_record_query = sqlalchemy.select(FinalAnswerModel).where(
             FinalAnswerModel.session_id == session_id
@@ -199,13 +197,12 @@ class ExperimentSessionMethods:
                 number_of_messages=-1,
             )
         )  # INSERT INTO final_answer (session_id, original_answer, edited_answer) VALUES (session_id, original_answer, edited_answer)
-        with db_engine.connect() as connection:
-            answer_model_record = connection.execute(answer_model_record_query)
+        with session_scope(connection_string) as session:
+            answer_model_record = session.execute(answer_model_record_query)
             if not answer_model_record.fetchone():
-                connection.execute(insertion_stmt)
+                session.execute(insertion_stmt)
             else:
-                connection.execute(update_stmt)
-            connection.commit()
+                session.execute(update_stmt)
 
     @staticmethod
     def update_session(
@@ -217,8 +214,8 @@ class ExperimentSessionMethods:
         """
         Update the final_answer table with the original and edited answers
         """
-        db_final_answer_engine = sqlalchemy.create_engine(
-            Utils.get_env_variable("FINAL_ANSWER_CONNECTION_STRING")
+        final_answer_connection_string = Utils.get_env_variable(
+            "FINAL_ANSWER_CONNECTION_STRING"
         )
         logger.info(f"Updating final answer for session_id: {session_id}")
         answer_model_record_query = sqlalchemy.select(FinalAnswerModel).where(
@@ -233,30 +230,30 @@ class ExperimentSessionMethods:
                 end_time=sqlalchemy.func.now(),  # pylint: disable=not-callable
             )
         )  # UPDATE final_answer SET original_answer = original_answer, edited_answer = edited_answer, end_time = NOW() WHERE session_id = session_id
-        with db_final_answer_engine.connect() as connection:
-            answer_model_record = connection.execute(answer_model_record_query)
+        with session_scope(final_answer_connection_string) as session:
+            answer_model_record = session.execute(answer_model_record_query)
             if not answer_model_record.fetchone():
                 raise ValueError(f"No record found for session_id: {session_id}")
-            connection.execute(update_stmt)
-            connection.commit()
-        db_chat_history_engine = sqlalchemy.create_engine(
-            Utils.get_env_variable("CHAT_HISTORY_CONNECTION_STRING")
+            session.execute(update_stmt)
+
+        chat_history_connection_string = Utils.get_env_variable(
+            "CHAT_HISTORY_CONNECTION_STRING"
         )
         count_stmt = sqlalchemy.select(
             sqlalchemy.func.count(ChatHistoryModel.id)  # pylint: disable=not-callable
         ).where(ChatHistoryModel.session_id == session_id)
-        with db_chat_history_engine.connect() as connection:
-            number_of_messages = connection.execute(count_stmt).scalar()
+        with session_scope(chat_history_connection_string) as session:
+            number_of_messages = session.execute(count_stmt).scalar()
             if number_of_messages is None:
                 raise ValueError(f"No chat history found for session_id: {session_id}")
+
         update_message_count = (
             sqlalchemy.update(FinalAnswerModel)
             .where(FinalAnswerModel.session_id == session_id)
             .values(number_of_messages=number_of_messages)
         )
-        with db_final_answer_engine.connect() as connection:
-            connection.execute(update_message_count)
-            connection.commit()
+        with session_scope(final_answer_connection_string) as session:
+            session.execute(update_message_count)
 
     @staticmethod
     def retrieve_sessions(logger: logging.Logger) -> list[dict[str, Any]]:

--- a/server_modules/models.py
+++ b/server_modules/models.py
@@ -1,31 +1,51 @@
 import json
-from sqlalchemy import JSON, Column, Integer, String, DateTime
-from sqlalchemy.orm import DeclarativeBase
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
-class Base(DeclarativeBase):
-    __abstract__ = True
+class ChatHistoryBase(DeclarativeBase):
+    """
+    Declarative base for models that live in the chat-history database.
+
+    Kept separate from :class:`FinalAnswerBase` so that ``metadata.create_all``
+    only creates the tables that belong to their respective database/engine.
+    """
 
 
-class SecondBase(DeclarativeBase):
-    __abstract__ = True
+class FinalAnswerBase(DeclarativeBase):
+    """
+    Declarative base for models that live in the final-answer database.
+
+    Kept separate from :class:`ChatHistoryBase` so that ``metadata.create_all``
+    only creates the tables that belong to their respective database/engine.
+    """
 
 
-class ChatHistoryModel(SecondBase):
+class ChatHistoryModel(ChatHistoryBase):
     __tablename__ = "message_store"
-    id = Column(Integer, primary_key=True)
-    session_id = Column(String(36))
-    message = Column(JSON)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    session_id: Mapped[str] = mapped_column(String(36))
+    message: Mapped[dict[str, Any]] = mapped_column(JSON)
 
 
-class FinalAnswerModel(Base):
+class FinalAnswerModel(FinalAnswerBase):
     __tablename__ = "final_answer"
-    session_id = Column(String(36), primary_key=True)
-    start_time = Column(DateTime)
-    end_time = Column(DateTime)
-    number_of_messages = Column(Integer, default=-1)
-    original_answer = Column(JSON)
-    edited_answer = Column(JSON)
+
+    session_id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    start_time: Mapped[datetime | None] = mapped_column(default=None)
+    end_time: Mapped[datetime | None] = mapped_column(default=None)
+    number_of_messages: Mapped[int] = mapped_column(default=-1)
+    original_answer: Mapped[dict[str, Any] | None] = mapped_column(JSON, default=None)
+    edited_answer: Mapped[dict[str, Any] | None] = mapped_column(JSON, default=None)
 
     def __repr__(self) -> str:
-        return f"FinalAnswer(session_id={self.session_id}, original_answer={json.dumps(self.original_answer)}, edited_answer={json.dumps(self.edited_answer)}, start_time={self.start_time}, end_time={self.end_time})"
+        return (
+            f"FinalAnswer(session_id={self.session_id}, "
+            f"original_answer={json.dumps(self.original_answer)}, "
+            f"edited_answer={json.dumps(self.edited_answer)}, "
+            f"start_time={self.start_time}, end_time={self.end_time})"
+        )

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -1,0 +1,163 @@
+import logging
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+
+from chatdoc.utils import Utils
+from server_modules.database import create_all_tables, get_engine, session_scope
+from server_modules.models import (
+    ChatHistoryBase,
+    ChatHistoryModel,
+    FinalAnswerBase,
+    FinalAnswerModel,
+)
+
+
+@pytest.fixture(name="final_answer_connection_string")
+def final_answer_connection_string_fixture(tmp_path: Path) -> str:
+    db_path = tmp_path / "final_answer.db"
+    connection_string = f"sqlite:///{db_path}"
+    create_all_tables(FinalAnswerBase, connection_string)
+    return connection_string
+
+
+@pytest.fixture(name="chat_history_connection_string")
+def chat_history_connection_string_fixture(tmp_path: Path) -> str:
+    db_path = tmp_path / "chat_history.db"
+    connection_string = f"sqlite:///{db_path}"
+    create_all_tables(ChatHistoryBase, connection_string)
+    return connection_string
+
+
+@pytest.fixture(name="env_connection_strings")
+def env_connection_strings_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    final_answer_connection_string: str,
+    chat_history_connection_string: str,
+) -> None:
+    monkeypatch.setenv(
+        "FINAL_ANSWER_CONNECTION_STRING", final_answer_connection_string
+    )
+    monkeypatch.setenv(
+        "CHAT_HISTORY_CONNECTION_STRING", chat_history_connection_string
+    )
+
+
+def test_get_engine_is_cached(final_answer_connection_string: str) -> None:
+    """
+    get_engine should return the same (cached) Engine instance for the same
+    connection string, to avoid creating a new connection pool every call.
+    """
+    first = get_engine(final_answer_connection_string)
+    second = get_engine(final_answer_connection_string)
+    assert first is second
+
+
+def test_create_all_tables_is_idempotent(final_answer_connection_string: str) -> None:
+    """
+    Calling create_all_tables twice should not raise, and the table should exist.
+    """
+    create_all_tables(FinalAnswerModel, final_answer_connection_string)
+    engine = get_engine(final_answer_connection_string)
+    inspector = sqlalchemy.inspect(engine)
+    assert "final_answer" in inspector.get_table_names()
+
+
+def test_session_scope_commits_on_success(final_answer_connection_string: str) -> None:
+    with session_scope(final_answer_connection_string) as session:
+        session.execute(
+            sqlalchemy.insert(FinalAnswerModel).values(session_id="abc")
+        )
+
+    with session_scope(final_answer_connection_string) as session:
+        row = session.execute(
+            sqlalchemy.select(FinalAnswerModel.__table__).where(
+                FinalAnswerModel.session_id == "abc"
+            )
+        ).mappings().first()
+    assert row is not None
+    assert row["session_id"] == "abc"
+
+
+def test_session_scope_rolls_back_on_error(final_answer_connection_string: str) -> None:
+    with pytest.raises(ValueError):
+        with session_scope(final_answer_connection_string) as session:
+            session.execute(
+                sqlalchemy.insert(FinalAnswerModel).values(session_id="rollback-me")
+            )
+            raise ValueError("boom")
+
+    with session_scope(final_answer_connection_string) as session:
+        row = session.execute(
+            sqlalchemy.select(FinalAnswerModel.__table__).where(
+                FinalAnswerModel.session_id == "rollback-me"
+            )
+        ).mappings().first()
+    assert row is None
+
+
+def test_chat_history_model_roundtrip(chat_history_connection_string: str) -> None:
+    with session_scope(chat_history_connection_string) as session:
+        session.execute(
+            sqlalchemy.insert(ChatHistoryModel).values(
+                session_id="sess-1", message={"role": "user", "content": "hi"}
+            )
+        )
+
+    with session_scope(chat_history_connection_string) as session:
+        rows = list(
+            session.execute(sqlalchemy.select(ChatHistoryModel.__table__)).mappings()
+        )
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == "sess-1"
+    assert rows[0]["message"] == {"role": "user", "content": "hi"}
+
+
+def test_experiment_session_lifecycle(env_connection_strings: None) -> None:
+    """
+    Exercise ExperimentSessionMethods end-to-end against sqlite databases,
+    covering add_new_session -> update_session -> retrieve_sessions /
+    retrieve_chat_history, mirroring how server_modules.methods uses these
+    functions in production.
+    """
+    from server_modules.methods import ExperimentSessionMethods
+
+    logger = logging.getLogger("test")
+    session_id = "session-123"
+
+    ExperimentSessionMethods.add_new_session(session_id, logger)
+
+    sessions = ExperimentSessionMethods.retrieve_sessions(logger)
+    assert len(sessions) == 1
+    assert sessions[0]["session_id"] == session_id
+    assert sessions[0]["number_of_messages"] == -1
+
+    with session_scope(
+        Utils.get_env_variable("CHAT_HISTORY_CONNECTION_STRING")
+    ) as session:
+        session.execute(
+            sqlalchemy.insert(ChatHistoryModel).values(
+                session_id=session_id, message={"role": "user", "content": "hi"}
+            )
+        )
+        session.execute(
+            sqlalchemy.insert(ChatHistoryModel).values(
+                session_id=session_id, message={"role": "assistant", "content": "hey"}
+            )
+        )
+
+    ExperimentSessionMethods.update_session(
+        session_id, {"original": True}, {"edited": True}, logger
+    )
+
+    sessions = ExperimentSessionMethods.retrieve_sessions(logger)
+    assert len(sessions) == 1
+    assert sessions[0]["number_of_messages"] == 2
+    assert sessions[0]["original_answer"] == {"original": True}
+    assert sessions[0]["edited_answer"] == {"edited": True}
+
+    with pytest.raises(ValueError):
+        ExperimentSessionMethods.update_session(
+            "unknown-session", {}, {}, logger
+        )


### PR DESCRIPTION
Closes #52

## Summary

- `server_modules/models.py`: rewritten to use SQLAlchemy 2.0 typed declarative
  models (`Mapped[...]` / `mapped_column(...)`) instead of legacy untyped
  `Column(...)` attributes. The two previously-empty `Base`/`SecondBase`
  marker classes are renamed to `FinalAnswerBase`/`ChatHistoryBase` with
  docstrings explaining why they're kept separate (so `metadata.create_all`
  only creates the tables belonging to their own database/engine).
- `server_modules/database.py` (new): centralizes engine creation
  (`get_engine`, cached per connection string via `lru_cache`), table
  creation (`create_all_tables`), and a `session_scope` context manager that
  handles session commit/rollback/close. This replaces three near-identical
  `sqlalchemy.create_engine(...)` + `with engine.connect() as connection: ...
  connection.commit()` blocks that were duplicated across
  `ExperimentSessionMethods`.
- `server_modules/methods.py`: `ExperimentSessionMethods` now goes through
  `session_scope`/`create_all_tables` instead of managing engines and raw
  `Connection` objects directly, while keeping the same public method
  signatures (`add_new_session`, `update_session`, `retrieve_sessions`,
  `retrieve_chat_history`) so this is an internal refactor only.
- `tests/database_test.py` (new): covers engine caching, idempotent table
  creation, `session_scope` commit/rollback behavior, `ChatHistoryModel`
  round-tripping, and an end-to-end `ExperimentSessionMethods` lifecycle test
  (add → update → retrieve) against sqlite databases.

No public function signatures used by `app.py` or `chatdoc/*` changed.

## Test plan

- [x] Verified the refactored models/database utilities manually against a
      sqlite database (insert/select/update round-trip, `session_scope`
      commit and rollback) since `poetry install` fails locally due to a
      `chroma-hnswlib` C++ build issue.
- [x] `tests/database_test.py` passes locally for the parts that don't
      require the full dependency set (5/6 tests, sqlalchemy-only); the
      remaining `ExperimentSessionMethods` lifecycle test needs
      `langchain`/`chatdoc` deps and is expected to run in CI.
- [ ] CI (`pytest tests/`) — pending, will monitor `gh pr checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)