### PR TITLE
Add WebSocket endpoints via Flask-SocketIO (issue #62)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,5 +122,15 @@ EXPOSE 8000
 # Enable debug port
 EXPOSE 5678
 
-# Execute Flask server on starting container
-CMD ["gunicorn", "-w", "2", "--threads", "4", "--preload", "-b", "0.0.0.0:8000", "--timeout", "600", "app:app"]
+# Execute Flask server on starting container.
+#
+# `app_ws:app` is the same Flask `app` object as `app:app`, with a
+# flask-socketio WebSocket layer attached on top (see app_ws.py). Real-time
+# WebSocket support under a WSGI stack like Flask requires a cooperative
+# worker class - `geventwebsocket.gunicorn.workers.GeventWebSocketWorker` -
+# rather than the default sync worker, so `--threads`/gthread is dropped, and
+# only a single worker (`-w 1`) is used since Flask-SocketIO needs clients
+# stuck to the same worker process (see app_ws.py for the full rationale,
+# including why this uses gevent instead of eventlet, and why it does NOT use
+# `uvicorn` - an ASGI server - as originally suggested in issue #62).
+CMD ["gunicorn", "-k", "geventwebsocket.gunicorn.workers.GeventWebSocketWorker", "-w", "1", "--preload", "-b", "0.0.0.0:8000", "--timeout", "600", "app_ws:app"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ mariadb+mariadbconnector://${MARIADB_USER}:${MARIADB_PASSWORD}@dora-mariadb
 ```
 Then run `poetry run flask --app server run`
 
+### WebSocket endpoint
+
+In addition to the HTTP endpoints served by `app.py`, `app_ws.py` exposes the
+same Flask application with a `flask-socketio` WebSocket layer attached.
+Connect a Socket.IO client to the server and emit a `prompt` event with a
+JSON payload of `{"sessionId": ..., "prompt": ...}`; the server responds with
+a `prompt_response` event carrying the same `message`/`error`/`result`
+payload shape as the HTTP `POST /prompt` endpoint. Both transports share the
+same underlying business logic (`resolve_prompt_response` in `app.py`), so
+they never diverge in behaviour.
+
+Locally, run it with `poetry run python app_ws.py` (uses `socketio.run`,
+suitable for development only). In the Docker image, gunicorn serves
+`app_ws:app` with the `gevent`-based WebSocket worker instead of `uvicorn`;
+see the comments in `app_ws.py` and the `Dockerfile` for why (uvicorn is an
+ASGI server, whereas Flask + flask-socketio is a WSGI stack whose real-time
+support depends on `eventlet`/`gevent`, not on ASGI).
+
 ## Run Flask server using Docker container
 
 Please configure the values in the Dockerfile before proceeding.

--- a/app.py
+++ b/app.py
@@ -388,6 +388,46 @@ async def delete_file() -> Response:
     return response
 
 
+async def resolve_prompt_response(
+    session_id: str, message: str
+) -> tuple[ResponseMessage | PromptResponse, int]:
+    """
+    Core business logic backing the "submit a prompt" use case.
+
+    This is intentionally transport-agnostic: it is used both by the HTTP
+    ``/prompt`` endpoint below and by the WebSocket ``prompt`` event handler
+    in ``app_ws.py``, so that the two transports never diverge in behaviour.
+
+    Args:
+        session_id (str): The session ID the prompt belongs to.
+        message (str): The prompt text submitted by the user.
+
+    Returns:
+        tuple: A tuple of the response payload and the associated HTTP-style
+        status code (still meaningful for the WebSocket transport as part of
+        the emitted payload, even though no actual HTTP status line is sent).
+    """
+    if not executor.futures.done(f"process_files_{session_id}"):
+        status = str(executor.futures._state(f"process_files_{session_id}"))
+        return (
+            ResponseMessage(
+                message="Files necessary for prompt are still processing, please try again in one minute.",
+                error=status,
+            ),
+            202,
+        )
+    else:
+        future = executor.futures.pop(f"process_files_{session_id}")
+        future.result()
+    chatbot = Chatbot(user_id=session_id, collection_name=session_id)
+    prompt_response = PromptResponse(
+        message="Prompt result is found under the result key.",
+        error="",
+        result=await chatbot.send_prompt(message),
+    )
+    return prompt_response, 200
+
+
 @app.route("/prompt", methods=["POST"])
 @swag_from("swagger/prompt.yml")
 async def prompt() -> Response:
@@ -398,26 +438,9 @@ async def prompt() -> Response:
         tuple: A tuple containing the response message and the HTTP status code.
     """
     session_id = str(get_property("sessionId"))
-    if not executor.futures.done(f"process_files_{session_id}"):
-        status = str(executor.futures._state(f"process_files_{session_id}"))
-        return make_response(
-            ResponseMessage(
-                message="Files necessary for prompt are still processing, please try again in one minute.",
-                error=status,
-            ),
-            202,
-        )
-    else:
-        future = executor.futures.pop(f"process_files_{session_id}")
-        future.result()
     message = str(get_property("prompt"))
-    chatbot = Chatbot(user_id=session_id, collection_name=session_id)
-    prompt_response = PromptResponse(
-        message="Prompt result is found under the result key.",
-        error="",
-        result=await chatbot.send_prompt(message),
-    )
-    return make_response(prompt_response, 200)
+    response_message, status_code = await resolve_prompt_response(session_id, message)
+    return make_response(response_message, status_code)
 
 
 @app.route("/get_chat_history", methods=["GET"])

--- a/app_ws.py
+++ b/app_ws.py
@@ -1,0 +1,106 @@
+"""
+WebSocket transport for the DoRA backend (issue #62).
+
+This module attaches a `flask_socketio.SocketIO` layer to the very same Flask
+application object defined in `app.py`, instead of duplicating the whole
+Flask app (routes, Swagger config, CORS/OPTIONS handling, error handler,
+executor, etc.). All HTTP routes defined in `app.py` keep working exactly as
+before; this module only adds a `prompt` WebSocket event as an alternative,
+bidirectional transport for the same use case that the HTTP `POST /prompt`
+endpoint serves.
+
+The actual business logic (looking up whether uploaded files are still being
+processed, invoking the `Chatbot`, shaping the response payload) lives in
+`app.resolve_prompt_response` and is shared by both transports, so it is not
+duplicated here.
+
+## A note on "uvicorn" (see issue #62)
+
+The original issue asked to "Add uvicorn as a service to the Dockerfile".
+That does not actually apply to this stack:
+
+- `uvicorn` is an **ASGI** server (it runs `async def app(scope, receive,
+  send)`-style applications, e.g. Starlette/FastAPI, or ASGI-wrapped WSGI
+  apps).
+- Flask (and `flask-socketio` on top of it) is a **WSGI** application.
+  `flask-socketio` achieves real-time, bidirectional WebSocket support on top
+  of a WSGI stack by using a cooperatively-scheduled worker (`eventlet` or
+  `gevent`) that can hold a connection open and still service other
+  greenlets/requests concurrently. `gunicorn` is told to use that worker via
+  a dedicated worker class, not by swapping in an ASGI server.
+- Running this Flask app under `uvicorn` directly would require wrapping it
+  with an ASGI adapter (e.g. `asgiref.wsgi.WsgiToAsgi`) and would *not* give
+  WebSocket support for free — `flask-socketio`'s WebSocket transport
+  specifically depends on the `eventlet`/`gevent` monkey-patching model, not
+  on ASGI.
+
+Given that, this change adds `gevent` + `gevent-websocket` (not `uvicorn`) as
+the async worker dependencies. `eventlet` was considered first (it is the
+worker most older Flask-SocketIO tutorials reach for), but as of 2024/2025
+`eventlet` is in maintenance-only "life support" mode with stalled feature
+development, so `gevent` — which is still actively maintained and is the
+option Flask-SocketIO's own docs currently steer new deployments towards —
+was chosen instead. The Dockerfile's gunicorn command now uses
+`-k geventwebsocket.gunicorn.workers.GeventWebSocketWorker` and serves
+`app_ws:app` (the same Flask `app` object, now with the SocketIO layer
+attached) so that both the existing HTTP routes and the new WebSocket
+endpoint are served from a single process/port. This is documented in the PR
+description as a deliberate deviation from the issue's literal wording.
+
+## A note on worker count
+
+Gunicorn is run with a single worker (`-w 1`) here. Flask-SocketIO relies on
+clients keeping a sticky connection to the same worker process for the
+lifetime of a session; gunicorn's built-in load balancing does not guarantee
+that, so with more than one worker some clients would fail to connect. Scaling
+to multiple workers/nodes requires a shared message queue (e.g. Redis) so
+that SocketIO instances across processes can coordinate broadcasts - that is
+out of scope for this change and left as a future improvement if/when
+horizontal scaling of the WebSocket endpoint is needed.
+"""
+
+import asyncio
+from typing import Any
+
+from flask_socketio import SocketIO, emit
+
+from app import app, resolve_prompt_response
+
+# `async_mode="gevent"` makes flask-socketio use gevent's cooperative
+# scheduler so that long-lived WebSocket connections don't block the worker
+# from handling other clients. See the module docstring above for why this
+# is `gevent` rather than `eventlet` or `uvicorn`/ASGI.
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="gevent")
+
+
+@socketio.on("prompt")
+def handle_prompt(data: dict[str, Any]) -> None:
+    """
+    Handles the prompt request from the client via WebSocket.
+
+    Mirrors the behaviour of the HTTP `POST /prompt` endpoint defined in
+    `app.py`, reusing the same `resolve_prompt_response` business logic.
+    Emits a `prompt_response` event back to the requesting client with the
+    same payload shape (`message`, `error`, and on success `result`) that the
+    HTTP endpoint returns as its JSON body.
+
+    Args:
+        data (dict): The payload sent by the client, expected to contain a
+            `sessionId` and a `prompt` key.
+    """
+    try:
+        session_id = str(data["sessionId"])
+        message = str(data["prompt"])
+        response_message, _status_code = asyncio.run(
+            resolve_prompt_response(session_id, message)
+        )
+        emit("prompt_response", response_message)
+    except Exception as error:  # pylint: disable=broad-except
+        emit("prompt_response", {"message": "", "error": str(error)})
+
+
+if __name__ == "__main__":
+    # Local/dev entrypoint. In production, gunicorn with the eventlet worker
+    # class serves `app_ws:app` directly (see Dockerfile), so this branch is
+    # not exercised in the container.
+    socketio.run(app, host="0.0.0.0", port=5000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ sqlalchemy = "^2.0.28"
 flask-executor = "^1.0.0"
 flasgger = "^0.9.7.1"
 nltk = "^3.8.1"
+flask-socketio = "^5.3.6"
+gevent = "^24.2.1"
+gevent-websocket = "^0.10.1"
 
 
 

--- a/tests/app_ws_test.py
+++ b/tests/app_ws_test.py
@@ -17,6 +17,7 @@ os.environ.setdefault(
 
 # pylint: disable=wrong-import-position
 import uuid
+from concurrent.futures import Future
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -40,8 +41,15 @@ def fixture_socketio_client(monkeypatch):
     """
     session_id = f"test-session-{uuid.uuid4()}"
 
-    already_done_future = app_module.executor.submit(lambda: None)
-    already_done_future.result()
+    # Build the completed future directly rather than via
+    # `app_module.executor.submit(...)`: the latter wraps the callable with
+    # `flask.copy_current_request_context`, which raises unless called from
+    # inside an active Flask request context - which this fixture is not
+    # (it runs before the socketio test client opens its own request
+    # context). A plain, already-resolved `concurrent.futures.Future` is all
+    # `FutureCollection`/`resolve_prompt_response` need.
+    already_done_future: Future = Future()
+    already_done_future.set_result(None)
     app_module.executor.futures.add(f"process_files_{session_id}", already_done_future)
 
     fake_chatbot = MagicMock()

--- a/tests/app_ws_test.py
+++ b/tests/app_ws_test.py
@@ -1,0 +1,95 @@
+"""
+Tests for the WebSocket transport added in `app_ws.py` (issue #62).
+
+`app.py` (and by extension `app_ws.py`, which reuses its Flask `app`
+instance) reads a couple of environment variables at import time
+(`CURRENT_ENV`, `LOGGING_FILE_PATH`). These are set here, before the
+`app`/`app_ws` modules are imported, so that importing them does not raise.
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("CURRENT_ENV", "TST")
+os.environ.setdefault(
+    "LOGGING_FILE_PATH", os.path.join(tempfile.gettempdir(), "dora-ws-test-logs", "dora-ws-test.log")
+)
+
+# pylint: disable=wrong-import-position
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app as app_module
+from app_ws import app as flask_app
+from app_ws import socketio
+
+
+@pytest.fixture(name="socketio_client")
+def fixture_socketio_client(monkeypatch):
+    """
+    Provides a `flask_socketio` test client connected to a session whose
+    "file processing" future is already resolved, so that emitting a
+    `prompt` event proceeds straight to invoking the (mocked) chatbot -
+    mirroring how the HTTP `/prompt` endpoint behaves once uploads are done.
+
+    A fresh, random session ID is used per test so that the shared
+    `executor.futures` collection (a process-wide global) can never leak
+    state between tests.
+    """
+    session_id = f"test-session-{uuid.uuid4()}"
+
+    already_done_future = app_module.executor.submit(lambda: None)
+    already_done_future.result()
+    app_module.executor.futures.add(f"process_files_{session_id}", already_done_future)
+
+    fake_chatbot = MagicMock()
+    fake_chatbot.send_prompt = AsyncMock(return_value={"answer": "42", "chat_history": []})
+    monkeypatch.setattr(app_module, "Chatbot", MagicMock(return_value=fake_chatbot))
+
+    client = socketio.test_client(flask_app)
+    try:
+        yield client, session_id, fake_chatbot
+    finally:
+        client.disconnect()
+
+
+def test_handle_prompt_emits_prompt_response(socketio_client):
+    """
+    A `prompt` event with a valid payload should be answered with a single
+    `prompt_response` event whose payload mirrors the HTTP `/prompt`
+    endpoint's JSON body, built from the shared `resolve_prompt_response`
+    business logic.
+    """
+    client, session_id, fake_chatbot = socketio_client
+
+    client.emit("prompt", {"sessionId": session_id, "prompt": "What is the answer?"})
+    received = client.get_received()
+
+    assert len(received) == 1
+    event = received[0]
+    assert event["name"] == "prompt_response"
+
+    payload = event["args"][0]
+    assert payload["error"] == ""
+    assert payload["result"] == {"answer": "42", "chat_history": []}
+    fake_chatbot.send_prompt.assert_called_once_with("What is the answer?")
+
+
+def test_handle_prompt_emits_error_on_malformed_payload(socketio_client):
+    """
+    A `prompt` event missing the required `prompt` key should not raise
+    inside the handler; instead an error should be reported back to the
+    client via a `prompt_response` event.
+    """
+    client, session_id, fake_chatbot = socketio_client
+
+    client.emit("prompt", {"sessionId": session_id})
+    received = client.get_received()
+
+    assert len(received) == 1
+    payload = received[0]["args"][0]
+    assert payload["message"] == ""
+    assert payload["error"]
+    fake_chatbot.send_prompt.assert_not_called()


### PR DESCRIPTION
Closes #62

## Summary

- Added `app_ws.py`, which attaches a `flask_socketio.SocketIO` layer to the *same* Flask `app` object defined in `app.py`, instead of literally duplicating the whole Flask app (routes, Swagger config, CORS/OPTIONS handling, error handler, executor, etc.). It exposes a `prompt` WebSocket event mirroring the existing `POST /prompt` HTTP endpoint: send `{"sessionId": ..., "prompt": ...}`, get back a `prompt_response` event with the same `message`/`error`/`result` payload shape as the HTTP endpoint.
- Extracted the core "resolve a prompt" logic out of `app.py`'s `prompt()` view into a new `resolve_prompt_response(session_id, message)` function, shared by both the HTTP route and the new WebSocket handler, so business logic is not duplicated across transports.
- Added `tests/app_ws_test.py`, using `flask_socketio`'s built-in `test_client` to exercise the WebSocket handler end-to-end (happy path + malformed-payload error path), following this repo's existing test conventions (pytest, fixtures, monkeypatching).
- Updated `pyproject.toml` and the `Dockerfile`'s gunicorn command accordingly (see deviation below).
- Documented the new endpoint in `README.md`.

## Deviation from the issue's literal wording: no `uvicorn`

The issue asked to "Add uvicorn as a service to the Dockerfile". After investigating, this doesn't fit the stack, and I did not add it:

- `uvicorn` is an **ASGI** server (Starlette/FastAPI-style `async def app(scope, receive, send)` apps, or ASGI-wrapped WSGI apps).
- Flask (and `flask-socketio` on top of it) is a **WSGI** application. `flask-socketio` gets real-time, bidirectional WebSocket support on a WSGI stack via a cooperatively-scheduled worker (`eventlet` or `gevent`), not via ASGI. Running this app under `uvicorn` directly (even wrapped with an ASGI adapter) would not give WebSocket support "for free" — flask-socketio's WebSocket transport specifically depends on the eventlet/gevent monkey-patching model.
- So, instead of `uvicorn`, this PR adds `gevent` + `gevent-websocket` as dependencies, and changes the Dockerfile's `CMD` to run gunicorn with `-k geventwebsocket.gunicorn.workers.GeventWebSocketWorker -w 1` serving `app_ws:app` (same Flask app, now with the SocketIO layer attached), rather than `app:app`.
  - `eventlet` was considered first since it's what most older Flask-SocketIO tutorials use, but it is now in "life support" maintenance mode with stalled development, so `gevent` (still actively maintained, and what Flask-SocketIO's own docs currently point new deployments towards) was used instead.
  - Only a single gunicorn worker is used (`-w 1`): Flask-SocketIO needs a client to stay connected to the same worker process for the life of its session, and gunicorn's load balancing doesn't guarantee that across multiple workers. Scaling this out to multiple workers/nodes would need a shared message queue (e.g. Redis) for SocketIO to coordinate across processes — left as a future improvement, out of scope here.

Full rationale is also documented in code comments in `app_ws.py` and the `Dockerfile`.

## Test plan

- [ ] CI: `python-tests` job (`poetry run pytest tests/`), including the new `tests/app_ws_test.py`
- [ ] CI: `docker-integration` job (builds the image with the updated Dockerfile/gunicorn command and brings up the stack)
- Note: I could not run `poetry install`/`pytest` locally in this environment — it lacks a C++ compiler needed to build `chroma-hnswlib` (a pre-existing, unrelated limitation of this sandbox, not introduced by this change) — so verification relies on GitHub Actions CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)