### PR TITLE
Reorder Dockerfile layers so MariaDB apt setup caches independently

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM python:3.11.7 AS builder
 # Set working directory
 WORKDIR /app
 
-# Copy poetry.lock and pyproject.toml
-COPY pyproject.toml /app/
-
 # Set Poetry environment variables
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
@@ -24,6 +21,10 @@ ENV PATH="$PATH:$POETRY_HOME/bin"
 # `mariadb_repo_setup` script's output file name/format (one-line `.list` vs.
 # deb822 `.sources`) is an undocumented implementation detail that has changed
 # upstream, which makes cross-stage COPY of that file fragile.
+#
+# This runs before `COPY pyproject.toml` (further down) so that this layer -
+# which never changes on its own - stays cached across the frequent
+# dependency bumps in pyproject.toml, instead of being invalidated by them.
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget gnupg \
     && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
     && chmod +x mariadb_repo_setup \
@@ -34,8 +35,12 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -
 # Install Poetry
 RUN pip install poetry
 
-# Install necessary dependencies
 RUN poetry config installer.max-workers 10
+
+# Copy poetry.lock and pyproject.toml
+COPY pyproject.toml /app/
+
+# Install necessary dependencies
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install -v --no-root
 
 #-----------------------------------------------------------------------------------
@@ -92,9 +97,6 @@ ENV SENTENCE_TRANSFORMERS_HOME=$EMBEDDING_MODEL_FOLDER_PATH
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 
-# Copy the virtual environment from the builder
-COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
-
 # Install MariaDB Connector/C runtime library.
 # We run the full repo-setup + install here (rather than COPYing apt sources
 # state from another stage) because `mariadb_repo_setup`'s output file
@@ -104,6 +106,10 @@ COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 # changes. Only the shared library is needed at runtime (not the -dev
 # headers, which are only required when building the `mariadb` wheel in the
 # builder stage above).
+#
+# This runs before `COPY --from=builder`/`COPY . /app` (further down) so that
+# this layer - which never changes on its own - stays cached across builds,
+# instead of being invalidated every time the venv or source changes.
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget gnupg \
     && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
     && chmod +x mariadb_repo_setup \
@@ -111,7 +117,8 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -
     && apt-get update && apt-get install -y libmariadb3 \
     && rm -f mariadb_repo_setup
 
-
+# Copy the virtual environment from the builder
+COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 # Copy current contents of folder to app directory
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,11 @@ ENV PATH="$PATH:$POETRY_HOME/bin"
 # This runs before `COPY pyproject.toml` (further down) so that this layer -
 # which never changes on its own - stays cached across the frequent
 # dependency bumps in pyproject.toml, instead of being invalidated by them.
-RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget gnupg \
+# Since this no longer depends on anything from the runtime stage (and vice
+# versa), BuildKit can run both stages' apt-get RUNs concurrently; they use
+# `sharing=locked` on the shared /var/cache/apt mount so BuildKit serializes
+# access instead of both processes racing for apt's own internal lock file.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && apt-get install -y wget gnupg \
     && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
     && chmod +x mariadb_repo_setup \
     && ./mariadb_repo_setup --mariadb-server-version="mariadb-10.11.18" \
@@ -109,8 +113,12 @@ ENV VIRTUAL_ENV=/app/.venv \
 #
 # This runs before `COPY --from=builder`/`COPY . /app` (further down) so that
 # this layer - which never changes on its own - stays cached across builds,
-# instead of being invalidated every time the venv or source changes.
-RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y wget gnupg \
+# instead of being invalidated every time the venv or source changes. Since
+# this no longer depends on the builder stage, BuildKit can run both stages'
+# apt-get RUNs concurrently; they use `sharing=locked` on the shared
+# /var/cache/apt mount so BuildKit serializes access instead of both
+# processes racing for apt's own internal lock file.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && apt-get install -y wget gnupg \
     && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
     && chmod +x mariadb_repo_setup \
     && ./mariadb_repo_setup --mariadb-server-version="mariadb-10.11.18" \


### PR DESCRIPTION
## Summary
- Moves the MariaDB Connector/C repo-setup + apt-get install ahead of `COPY pyproject.toml` (builder stage) and `COPY --from=builder`/`COPY . /app` (runtime stage) in both Docker stages.
- Previously those COPY instructions changed on nearly every dependency bump or source edit, which invalidated the MariaDB apt layer right along with them — forcing a repeated `wget`/`apt-get` network round-trip on every build even though the MariaDB setup command itself never changes.
- With this reorder, BuildKit can cache the MariaDB layer independently, so it only re-runs when that RUN command's content actually changes.

Context: this came out of investigating why `docker-integration` CI consistently took ~4 minutes even with the GHA layer cache (added in #57) in place — `pyproject.toml` has changed in nearly every recently-merged PR, cache-busting this otherwise-static layer every time.

## Test plan
- [x] CI `docker-integration` job builds and passes
- [x] Manually verify with a second local build (touching only source, not pyproject.toml) that the MariaDB layer shows `CACHED`