### PR TITLE
Use prebuilt CPU wheel for llama-cpp-python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,22 @@ FROM python:3.11.7 AS builder
 # Set working directory
 WORKDIR /app
 
+# Selects which llama-cpp-python backend gets installed. Defaults to "cpu",
+# which uses the prebuilt CPU-only wheel pinned in pyproject.toml (source
+# "llama-cpp-python-cpu") - this avoids a multi-minute from-source compile on
+# every build, but means the image cannot use a GPU for local LLM inference.
+#
+# To build a GPU-capable image instead, override this at build time, e.g.:
+#   docker build --build-arg LLAMA_CPP_BACKEND=cuda .
+# Supported values: "cpu" (default), "cuda" (NVIDIA/CUBLAS), "metal" (Apple
+# Silicon). Anything other than "cpu" forces llama-cpp-python to be
+# recompiled from source with the matching backend enabled - see the RUN
+# step below and README.md for the full picture, including the additional
+# runtime-image/base-image and nvidia-container-toolkit requirements for
+# actually using a GPU in the running container.
+ARG LLAMA_CPP_BACKEND=cpu
+ENV LLAMA_CPP_BACKEND=$LLAMA_CPP_BACKEND
+
 # Set Poetry environment variables
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
@@ -47,10 +63,31 @@ COPY pyproject.toml /app/
 # Install necessary dependencies
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install -v --no-root
 
+# `poetry install` above always installs the prebuilt CPU wheel for
+# llama-cpp-python (it's pinned to that source in pyproject.toml). If a
+# non-cpu backend was requested via LLAMA_CPP_BACKEND, force a from-source
+# rebuild with the matching CMake flags enabled, replacing that CPU wheel.
+# Poetry's venv (POETRY_VIRTUALENVS_IN_PROJECT=true) isn't on PATH in this
+# stage, so its pip is invoked directly.
+RUN if [ "$LLAMA_CPP_BACKEND" = "cuda" ]; then \
+        CMAKE_ARGS="-DLLAMA_CUBLAS=on" /app/.venv/bin/pip install --force-reinstall --no-cache-dir --no-binary llama-cpp-python "llama-cpp-python==0.2.11"; \
+    elif [ "$LLAMA_CPP_BACKEND" = "metal" ]; then \
+        CMAKE_ARGS="-DLLAMA_METAL=on" /app/.venv/bin/pip install --force-reinstall --no-cache-dir --no-binary llama-cpp-python "llama-cpp-python==0.2.11"; \
+    elif [ "$LLAMA_CPP_BACKEND" != "cpu" ]; then \
+        echo "Unknown LLAMA_CPP_BACKEND '$LLAMA_CPP_BACKEND' (expected cpu, cuda, or metal)" >&2 && exit 1; \
+    fi
+
 #-----------------------------------------------------------------------------------
 
 ## Runtime Image
 FROM  python:3.11.7 AS runtime
+
+# Re-declared so the value used to build this image (see the builder stage
+# above) is visible/inspectable in the running container, e.g. via
+# `docker inspect` or `printenv`. This does not select the backend itself -
+# that already happened in the builder stage - it's informational only.
+ARG LLAMA_CPP_BACKEND=cpu
+ENV LLAMA_CPP_BACKEND=$LLAMA_CPP_BACKEND
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ docker run --name <container_name> -p 5000:8000 dora-back \
 You can access the server at localhost:5000.
 Overriding the default values for the environment variables is optional.
 
+### GPU support for local models (`LLAMA_CPP_BACKEND`)
+
+By default, the Docker image installs `llama-cpp-python` from a prebuilt **CPU-only** wheel (see `[[tool.poetry.source]]` in `pyproject.toml`), instead of compiling it from source, since that used to be the single largest contributor to Docker build times. This means a default-built image cannot use a GPU for local LLM inference (`CHAT_MODEL_VENDOR_NAME=local`/`EMBEDDING_MODEL_VENDOR_NAME=local`).
+
+To build an image with GPU support instead, override the `LLAMA_CPP_BACKEND` build arg:
+```bash
+docker build --build-arg LLAMA_CPP_BACKEND=cuda -t dora-backend .
+# or, with docker compose:
+LLAMA_CPP_BACKEND=cuda docker compose build dora-backend
+```
+Supported values are `cpu` (default), `cuda` (NVIDIA/CUBLAS), and `metal` (Apple Silicon). Setting anything other than `cpu` forces `llama-cpp-python` to be recompiled from source with the corresponding CMake flags enabled (see the Dockerfile for details) - this is the same trade-off the pre-existing "Allow GPU-inference for local models" section above describes for the Poetry-based (non-Docker) setup, just wired up as a build arg here.
+
+Note that this only controls **which `llama-cpp-python` build gets installed**. Actually exercising a GPU from inside the container additionally requires:
+- Building `FROM` a CUDA-enabled base image (e.g. an `nvidia/cuda` image) instead of the plain `python:3.11.7` image used here, with a matching CUDA toolkit version - not currently wired up in this Dockerfile.
+- Running the container with GPU access, e.g. `docker run --gpus all ...` and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed on the host.
+
 ## Removing CORS and connecting to remote Vector DB
 To be able to remove the CORS wrapper and connect to a remote vector database, set the `CURRENT_ENV` variable to `PROD`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        LLAMA_CPP_BACKEND: ${LLAMA_CPP_BACKEND:-cpu}
     develop:
       watch:
         - action: rebuild

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ pytest = "^7.4.3"
 pydantic = "^2.5.3"
 langchain-community = ">=0.0.9,<0.1.0"
 langchain-core = "^0.1.7"
-llama-cpp-python = "0.2.11"
+llama-cpp-python = {version = "0.2.11", source = "llama-cpp-python-cpu"}
 gunicorn = "20.1.0"
 mariadb = "^1.1.10"
 sqlalchemy = "^2.0.28"
@@ -37,6 +37,17 @@ gevent-websocket = "^0.10.1"
 [tool.poetry.group.dev.dependencies]
 jupyter = "^1.0.0"
 debugpy = "^1.8.5"
+
+# Prebuilt CPU-only wheels for llama-cpp-python, published by the project
+# maintainer. PyPI only ships an sdist, so without this source poetry/pip
+# must compile the C++ inference library from scratch on every cold Docker
+# build (a multi-minute step). This source is only consulted for packages
+# that explicitly reference it by name (priority = "explicit"), so it has no
+# effect on dependency resolution for anything else.
+[[tool.poetry.source]]
+name = "llama-cpp-python-cpu"
+url = "https://abetlen.github.io/llama-cpp-python/whl/cpu"
+priority = "explicit"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- Pins `llama-cpp-python`'s Poetry source to `https://abetlen.github.io/llama-cpp-python/whl/cpu` (the maintainer's prebuilt CPU-wheel index), instead of the default PyPI sdist.
- PyPI only publishes an sdist for `llama-cpp-python`, so every cold Docker build was compiling the C++ inference library from scratch — this was the single largest chunk (~1-2 min) of the ~4 minute `docker-integration` build time.
- The source is registered with `priority = "explicit"` and only referenced by `llama-cpp-python` itself, so it has no effect on how any other dependency resolves.

## Risk / things to verify in CI
This is the riskier of the two Docker speed-up changes (paired with #85, the layer-reordering PR): it depends on the maintainer's wheel index actually publishing a wheel for the exact pinned version (`0.2.11`) and platform/Python combination this project builds on (linux/manylinux, cp311). I couldn't verify reachability of that index or wheel availability from this sandbox (no network egress), so:

## Test plan
- [ ] `python-tests` CI job's `poetry install --no-root` step succeeds and pulls a wheel (not an sdist build) for `llama-cpp-python`
- [ ] `docker-integration` CI job's Docker build succeeds and is measurably faster than before
- [ ] If the wheel isn't available for this version/platform, poetry will hard-fail resolution (explicit source, no automatic PyPI fallback) - if so, this needs to fall back to a compatible pinned version instead