### PR TITLE
[STALE?] Create VectorDB service (old branch, may be superseded by #79)

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,13 +25,13 @@ from server_modules.class_defs import (
     PromptResponse,
     ChatHistoryResponse,
     WEMUploadResponse,
-    SessionQueryResponse,	
+    SessionQueryResponse,
 )
 from chatdoc.chatbot import Chatbot
 from chatdoc.utils import Utils
 
 
-set_logging_config(Utils.get_env_variable("LOGGING_FILE_PATH"))
+set_logging_config(Utils.get_env_variable("LOGGING_FILE_DIR"))
 
 
 app = Flask(__name__)
@@ -95,7 +95,7 @@ def get_property(
             f"No {property_name} found in request.form, session, or request.json"
         )
     if property_type == str:
-        return str(property_value).replace("\"", "")
+        return str(property_value).replace('"', "")
     if issubclass(property_type, Basic):
         return cast(property_type, property_value)
     return json.loads(property_value)
@@ -275,6 +275,7 @@ def upload_files_json() -> Response:
     response = make_response(response_message, 200)
     return response
 
+
 @app.route("/get_file_id_mappings", methods=["GET"])
 def get_file_id_mappings() -> Response:
     """
@@ -293,7 +294,6 @@ def get_file_id_mappings() -> Response:
     future = executor.futures.pop("process_files")
     response_message = future.result()
     return make_response(response_message, 200)
-
 
 
 @app.route("/upload_files", methods=["POST"])
@@ -436,6 +436,7 @@ def submit_final_answer() -> Response:
         message="Final answer successfully submitted!", error=""
     )
     return make_response(response_message, 200)
+
 
 @app.route("/get_sessions", methods=["GET"])
 def get_sessions() -> Response:

--- a/chatdoc/vector_db.py
+++ b/chatdoc/vector_db.py
@@ -1,6 +1,7 @@
 """
 Module definine the VectorDatabase class
 """
+
 import os
 from typing import Literal, TypedDict
 from langchain.embeddings.base import Embeddings
@@ -68,6 +69,7 @@ class CustomVectorStoreRetriever(VectorStoreRetriever):
             doc.metadata["ranking"] = i + 1
         return docs
 
+
 class VectorDatabase:
     """
     The VectorDatabase class that creates a ChromaDB store locally
@@ -96,18 +98,23 @@ class VectorDatabase:
                 raise ValueError("Invalid DORA environment")
         return self._chroma_db_client
 
-    def __init__(self, collection_name: str, embedding_fn: Embeddings) -> None:
+    def __init__(
+        self,
+        collection_name: str,
+        embedding_fn: Embeddings,
+        persist_dir: str = "./chroma_db",
+    ) -> None:
         self.collection_name = collection_name
         self.chroma_instance = Chroma(
             collection_name=collection_name,
             client=self.chroma_client,
             embedding_function=embedding_fn,
-            persist_directory="./chroma_db",
+            persist_directory=os.environ.get("CHROMA_DB_PERSIST_DIR", persist_dir),
         )
         self.retriever_settings: RetrieverSettings = self.load_retriever_settings()
         self.retriever = CustomVectorStoreRetriever(
             vectorstore=self.chroma_instance,
-            **self.retriever_settings, # type: ignore
+            **self.retriever_settings,  # type: ignore
         )
 
     def load_retriever_settings(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       LOGGING_FILE_DIR: /app/logs
     volumes:
       - logging_file_dir:/app/logs
-      - ${CHAT_MODEL_FOLDER_PATH:?error:/models/chat_models
+      - ${CHAT_MODEL_FOLDER_PATH:?error}:/models/chat_models
       - ${SENTENCE_TRANSFORMERS_HOME:?error}:/models/embedding_models
     depends_on:
       - dora-mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 name: dora-services
 networks:
   net:
@@ -10,9 +9,9 @@ services:
     volumes:
       - chromadb_data:/chroma/chroma
     environment:
-      - IS_PERSISTENT: TRUE
-      - PERSIST_DIRECTORY: ${CHROMA_DB_PERSIST_DIR}
-      - ANONYMIZED_TELEMETRY: ${ANONYMIZED_TELEMETRY:-TRUE}
+      IS_PERSISTENT: "TRUE"
+      PERSIST_DIRECTORY: ${CHROMA_DB_PERSIST_DIR}
+      ANONYMIZED_TELEMETRY: ${ANONYMIZED_TELEMETRY:-TRUE}
     ports:
       - 8000:8000
     networks:
@@ -34,25 +33,29 @@ services:
 
   dora-backend:
     image: docker.io/library/dora-backend:latest
+    build: 
+      context: .
+      dockerfile: Dockerfile
     ports:
       - 30080:8000
     restart: "always"
     environment:
-      FLASK_PORT: ${FLASK_PORT}
-      TOP_K_DOCUMENTS: ${TOP_K_DOCUMENTS}
-      MINIMUM_ACCURACY: ${MINIMUM_ACCURACY}
-      FETCH_K_DOCUMENTS: ${FETCH_K_DOCUMENTS}
-      LAMBDA_MULT: ${LAMBDA_MULT}
-      STRATEGY: mmr
-      CHAT_HISTORY_CONNECTION_STRING: ${MARIADB_INSTANCE_URL}/experiment
-      FINAL_ANSWER_CONNECTION_STRING: ${MARIADB_INSTANCE_URL}/experiment
+      FLASK_PORT: ${FLASK_PORT:?error}
+      TOP_K_DOCUMENTS: ${TOP_K_DOCUMENTS:?error}
+      MINIMUM_ACCURACY: ${MINIMUM_ACCURACY:?error}
+      FETCH_K_DOCUMENTS: ${FETCH_K_DOCUMENTS:?error}
+      LAMBDA_MULT: ${LAMBDA_MULT:?error}
+      STRATEGY: ${STRATEGY:?error}
+      CHAT_HISTORY_CONNECTION_STRING: ${MARIADB_INSTANCE_URL:?error}/experiment
+      FINAL_ANSWER_CONNECTION_STRING: ${MARIADB_INSTANCE_URL:?error}/experiment
       FLASK_APP: ./app.py
       HTTP_PROXY: ${HTTP_PROXY}
       HTTPS_PROXY: ${HTTPS_PROXY}
+      LOGGING_FILE_DIR: /app/logs
     volumes:
       - logging_file_dir:/app/logs
-      - chat_model_folder_path:/models/chat_models
-      - embedding_model_folder_path:/models/embedding_models
+      - ${CHAT_MODEL_FOLDER_PATH:?error:/models/chat_models
+      - ${SENTENCE_TRANSFORMERS_HOME:?error}:/models/embedding_models
     depends_on:
       - dora-mariadb
     labels:
@@ -60,17 +63,9 @@ services:
       kompose.volume.type: hostPath
       kompose.image-pull-policy: "Never"
 
-  volumes:
-    chat_model_folder_path:
-      external:
-        name: ${CHAT_MODEL_FOLDER_PATH}
-    embedding_model_folder_path:
-      external:
-        name: ${SENTENCE_TRANSFORMERS_HOME}
-    logging_file_dir:
-      external:
-        name: ${LOGGING_FILE_DIR}
-    mariadb_data:
-    chromadb_data:
+volumes:
+  logging_file_dir:
+  mariadb_data:
+  chromadb_data:
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,28 @@
-version: '3'
+version: '3.9'
 name: dora-services
+networks:
+  net:
+    driver: bridge
+
 services:
+  dora-chromadb:
+    image: chromadb/chroma:latest
+    volumes:
+      - chromadb_data:/chroma/chroma
+    environment:
+      - IS_PERSISTENT: TRUE
+      - PERSIST_DIRECTORY: ${CHROMA_DB_PERSIST_DIR}
+      - ANONYMIZED_TELEMETRY: ${ANONYMIZED_TELEMETRY:-TRUE}
+    ports:
+      - 8000:8000
+    networks:
+      - net
   dora-mariadb:
     image: mariadb:latest
     ports:
       - "3306:3306"
     volumes:
-      - ~/dora-mariadb:/var/lib/mysql # Add mapping to store DB files on permanent storage
+      - mariadb_data:/var/lib/mysql # Add mapping to store DB files on permanent storage
     environment:
       MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
       MARIADB_USER: ${MARIADB_USER}
@@ -19,14 +35,14 @@ services:
   dora-backend:
     image: docker.io/library/dora-backend:latest
     ports:
-      - "30080:8000"
+      - 30080:8000
     restart: "always"
     environment:
-      FLASK_PORT: 5000
-      TOP_K_DOCUMENTS: 10
-      MINIMUM_ACCURACY: 0.50
-      FETCH_K_DOCUMENTS: 100
-      LAMBDA_MULT: 0.2
+      FLASK_PORT: ${FLASK_PORT}
+      TOP_K_DOCUMENTS: ${TOP_K_DOCUMENTS}
+      MINIMUM_ACCURACY: ${MINIMUM_ACCURACY}
+      FETCH_K_DOCUMENTS: ${FETCH_K_DOCUMENTS}
+      LAMBDA_MULT: ${LAMBDA_MULT}
       STRATEGY: mmr
       CHAT_HISTORY_CONNECTION_STRING: ${MARIADB_INSTANCE_URL}/experiment
       FINAL_ANSWER_CONNECTION_STRING: ${MARIADB_INSTANCE_URL}/experiment
@@ -34,13 +50,27 @@ services:
       HTTP_PROXY: ${HTTP_PROXY}
       HTTPS_PROXY: ${HTTPS_PROXY}
     volumes:
-      - ~/dora-logs/dora-backend:/app/logs
-      # - chat_model_folder_path:/models/chat_models
-      # - embedding_model_folder_path:/models/embedding_models
+      - logging_file_dir:/app/logs
+      - chat_model_folder_path:/models/chat_models
+      - embedding_model_folder_path:/models/embedding_models
     depends_on:
       - dora-mariadb
     labels:
       kompose.service.type: nodeport
       kompose.volume.type: hostPath
       kompose.image-pull-policy: "Never"
+
+  volumes:
+    chat_model_folder_path:
+      external:
+        name: ${CHAT_MODEL_FOLDER_PATH}
+    embedding_model_folder_path:
+      external:
+        name: ${SENTENCE_TRANSFORMERS_HOME}
+    logging_file_dir:
+      external:
+        name: ${LOGGING_FILE_DIR}
+    mariadb_data:
+    chromadb_data:
+
 

--- a/server_modules/__init__.py
+++ b/server_modules/__init__.py
@@ -1,32 +1,43 @@
 from logging.config import dictConfig
+from typing import Any
 import os
 
-def set_logging_config(filename: str, max_bytes: int = 1_000_000, backup_count: int = 5):
-    if filename == "":
-        raise ValueError("Filename cannot be empty.")
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
-    dictConfig(
-    {
-        "version": 1,
-        "formatters": {
-            "default": {
-                "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
-            }
-        },
-        "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "stream": "ext://sys.stdout",
-                "formatter": "default",
-            },
-            "file": {
-                "class": "logging.handlers.RotatingFileHandler",
-                "filename": filename,
-                "maxBytes": max_bytes,
-                "backupCount": backup_count,
-                "formatter": "default",
-            },
-        },
-        "root": {"level": "INFO", "handlers": ["console", "file"]},
+
+def set_logging_config(
+    directory: str, max_bytes: int = 1_000_000, backup_count: int = 5
+):
+    if directory == "":
+        raise ValueError("Directory cannot be empty.")
+
+    os.makedirs(directory, exist_ok=True)
+    log_files = ["app.log", "error.log", "debug.log"]
+
+    handlers: dict[str, Any] = {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+            "formatter": "default",
+        }
     }
-)
+
+    for log_file in log_files:
+        handlers[log_file] = {
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": os.path.join(directory, log_file),
+            "maxBytes": max_bytes,
+            "backupCount": backup_count,
+            "formatter": "default",
+        }
+
+    dictConfig(
+        {
+            "version": 1,
+            "formatters": {
+                "default": {
+                    "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+                }
+            },
+            "handlers": handlers,
+            "root": {"level": "INFO", "handlers": list(handlers.keys())},
+        }
+    )


### PR DESCRIPTION
## What this branch contains
An older, manual attempt at issue #38 ("Create VectorDB service") from 2024, predating today's automated pass:
- `docker-compose.yml`: defines named volumes instead of local bind mappings, for the persist_dir and other paths.
- `chatdoc/vector_db.py`: converts `persist_dir` into an environment variable.
- `server_modules/__init__.py`: logging fixes for multiple log files/environment variable naming.
- `app.py`: minor related fixes.

## Caveat - likely superseded
Issue #38 was already implemented and merged today via PR #79 ("Add Chroma VectorDB service to docker-compose"), which took a different approach: it runs an actual `chromadb/chroma` server container and wires `VectorDatabase` to connect to it via `chromadb.HttpClient`, rather than this branch's volume/env-var refactor of the local persistent-client setup. The two approaches are **not** the same solution to the same problem.

## Recommendation
Please assess whether anything in this branch (the docker-compose volume definitions, the logging fixes) is still wanted on top of #79's approach, or whether this can be closed/pruned as superseded. Not rebased onto current main - expect conflicts given how much has changed in docker-compose.yml and vector_db.py since 2024.

## Test plan
- [ ] Decide: keep any of this, or close as superseded by #79?