### PR TITLE
Add deploy.yml: build and publish CPU/GPU images to GHCR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+env:
+  IMAGE_NAME: ghcr.io/iodine98/dora-back
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - variant: cpu
+            llama_cpp_backend: cpu
+          - variant: gpu
+            llama_cpp_backend: cuda
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (${{ matrix.variant }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            LLAMA_CPP_BACKEND=${{ matrix.llama_cpp_backend }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ matrix.variant }}
+            ${{ env.IMAGE_NAME }}:${{ matrix.variant }}-${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}


### PR DESCRIPTION
Closes #90

## Summary
- Adds `.github/workflows/deploy.yml`, triggered on push to `main` and via manual `workflow_dispatch`.
- Builds two image variants in a matrix using the `LLAMA_CPP_BACKEND` build arg introduced in #86:
  - `ghcr.io/iodine98/dora-back:cpu` (+ `:cpu-<sha>`) - `LLAMA_CPP_BACKEND=cpu`
  - `ghcr.io/iodine98/dora-back:gpu` (+ `:gpu-<sha>`) - `LLAMA_CPP_BACKEND=cuda`
- Pushes to GitHub Container Registry using the built-in `GITHUB_TOKEN` (`packages: write` permission) - no new secrets or infrastructure required.
- Reuses the `type=gha` layer cache pattern from `ci.yml`, scoped per variant so the cpu/gpu builds don't evict each other's cache.

## Dependency on #86
The `gpu` variant only actually takes effect once #86 (which adds the `LLAMA_CPP_BACKEND` arg to the Dockerfile) is merged. Until then, Docker will just warn that the build-arg is unconsumed and both variants will silently build identically (CPU). Recommend merging #86 before/alongside this.

## Note on testing
Since this workflow only triggers on `push: branches: [main]`, it cannot run/be validated from this PR branch directly (`workflow_dispatch` also requires the workflow to already exist on the default branch to be dispatchable). It'll get its first real run on merge to `main` - recommend watching that run once merged, and reverting/fixing forward quickly if anything's off.

## Test plan
- [ ] After merging (and once #86 is merged), confirm both `cpu` and `gpu` tags appear in the repo's GHCR packages
- [ ] Confirm the `gpu` image actually built with `-DLLAMA_CUBLAS=on` (e.g. check build logs for the from-source compile step)