### PR TITLE
Use python:3.11-slim for runtime + cache Poetry deps in python-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libmariadb-dev
 
+      # There's no committed poetry.lock (see .gitignore), so the cache key
+      # is hashed from pyproject.toml instead - it still gets invalidated
+      # whenever dependencies change, just at slightly coarser granularity
+      # than a lock-file hash would give. Caches Poetry's own cache dir
+      # (~/.cache/pypoetry), which holds both downloaded/built wheel
+      # artifacts and, since POETRY_VIRTUALENVS_IN_PROJECT isn't set here,
+      # the virtualenv itself - so a cache hit skips reinstalling entirely,
+      # not just re-downloading.
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-${{ runner.os }}-py3.11.7-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-py3.11.7-
+
       - name: Install dependencies
         run: poetry install --no-root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,14 @@ RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install -v --no-root
 #-----------------------------------------------------------------------------------
 
 ## Runtime Image
-FROM  python:3.11.7 AS runtime
+# Uses the slim variant here (unlike the builder stage) since this stage
+# only runs the already-built venv/app code - it never compiles anything
+# (mariadb/llama-cpp-python are only built from source in the builder
+# stage), so it doesn't need the extra build tooling the full python image
+# carries. This meaningfully shrinks the final image (and therefore the
+# image-export/GHA-cache-upload time that dominates docker-integration CI -
+# see the discussion on #85/#86).
+FROM python:3.11-slim AS runtime
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,11 @@ ENV VIRTUAL_ENV=/app/.venv \
 # apt-get RUNs concurrently; they use `sharing=locked` on the shared
 # /var/cache/apt mount so BuildKit serializes access instead of both
 # processes racing for apt's own internal lock file.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && apt-get install -y wget gnupg \
+#
+# `curl` is included because `mariadb_repo_setup` itself checks for it as a
+# prerequisite - the full python image happens to have it preinstalled, but
+# python:3.11-slim (used for this stage) doesn't.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && apt-get install -y wget gnupg curl \
     && wget https://r.mariadb.com/downloads/mariadb_repo_setup \
     && chmod +x mariadb_repo_setup \
     && ./mariadb_repo_setup --mariadb-server-version="mariadb-10.11.18" \


### PR DESCRIPTION
## Summary
- Switches only the **runtime** stage's base image from `python:3.11.7` (full) to `python:3.11-slim`. The **builder** stage stays on the full image since it needs a C compiler (to build the `mariadb` package from sdist, and optionally `llama-cpp-python` for GPU backends).
- Adds `curl` to the runtime stage's apt install - `mariadb_repo_setup` checks for it as a prerequisite, and unlike the full image, slim doesn't have it preinstalled (this was caught by CI on the first push).
- Also caches Poetry's dependencies in the `python-tests` job (`~/.cache/pypoetry`, keyed on a hash of `pyproject.toml` since there's no committed `poetry.lock`) - that job was running `poetry install --no-root` fully cold on every run with zero caching.

## Context
Following up on the #85/#86 investigation into `docker-integration` CI build times: the dominant cost turned out to be fixed overhead (exporting the built image to Docker format, loading it into the daemon, and uploading every layer to the GHA cache) that scales with total image size (~570-600MB), not with anything in the Dockerfile's RUN steps. Shrinking the final image is the actual lever left to pull for that job. The `python-tests` caching is a separate, unrelated-but-easy win noticed along the way.

## Test plan
- [ ] `docker-integration` CI job builds and the `dora-backend` container actually starts/responds successfully (not just that `docker build` succeeds - a missing shared library would likely fail at runtime/import time, not build time)
- [ ] Compare the resulting image size and the `docker-integration` job's total wall-clock time against a recent run without this change
- [ ] Confirm a second `python-tests` run (e.g. an empty commit / re-run) shows a cache hit and skips reinstalling dependencies